### PR TITLE
convert commands to string API

### DIFF
--- a/botCommands/help.js
+++ b/botCommands/help.js
@@ -1,6 +1,6 @@
 const {registerBotCommand} = require("../botEngine.js");
 
-registerBotCommand(/\B\/help\b/, ({room}) => {
+registerBotCommand("/help", ({room}) => {
   return `
   **By posting in this chatroom you agree to our code of conduct:** <https://github.com/TheOdinProject/theodinproject/blob/master/doc/code_of_conduct.md>
 
@@ -16,7 +16,7 @@ Motivate your fellow odinites with \`/motivate\` and mention them
 I'm open source!  Hack me HERE: <https://github.com/codyloyd/odin-bot-v2>`;
 });
 
-registerBotCommand(/\B\/code\b/, ({room}) => {
+registerBotCommand("/code", ({room}) => {
   return `
 **HOW TO EMBED CODE SNIPPETS**
 To write multiple lines of code use three backticks <https://i.stack.imgur.com/ETTnT.jpg> (on their own line, \`shift + enter\` makes new lines):

--- a/botCommands/partyParrot.js
+++ b/botCommands/partyParrot.js
@@ -2,7 +2,7 @@ const {registerBotCommand} = require("../botEngine.js");
 const {randomInt} = require("./helpers.js");
 
 registerBotCommand(
-  /partyparrot|party_parrot|party parrot|oiseau/,
+  "partyparrot|party_parrot|party parrot|oiseau",
   ({content}) => {
     const parrots = [
       "https://cultofthepartyparrot.com/parrots/hd/dadparrot.gif",

--- a/botCommands/points.js
+++ b/botCommands/points.js
@@ -2,7 +2,9 @@ const axios = require("axios");
 const config = require("../config.js");
 const { registerBotCommand } = require("../botEngine.js");
 
-const AWARD_POINT_REGEX = ["<@!?(\d+)>\s?(\+\+|\u{2b50})", "gu"];
+// if you change one change the other to match 
+const AWARD_POINT_REGEX = /<@!?(\d+)>\s?(\+\+|\u{2b50})/gu;
+const API_CONSISTENT_AWARD_POINT_REGEX = ["<@!?(\d+)>\s?(\+\+|\u{2b50})", "gu"];
 
 if (process.argv.includes('dev')) {
   return;
@@ -102,7 +104,7 @@ async function pointsBotCommand({ author, content, channel, client }) {
   });
 }
 
-registerBotCommand(AWARD_POINT_REGEX, pointsBotCommand);
+registerBotCommand(API_CONSISTENT_AWARD_POINT_REGEX, pointsBotCommand);
 
 registerBotCommand("/points", async function({
   content,

--- a/botCommands/points.js
+++ b/botCommands/points.js
@@ -2,7 +2,7 @@ const axios = require("axios");
 const config = require("../config.js");
 const { registerBotCommand } = require("../botEngine.js");
 
-const AWARD_POINT_REGEX = /<@!?(\d+)>\s?(\+\+|\u{2b50})/gu;
+const AWARD_POINT_REGEX = ["<@!?(\d+)>\s?(\+\+|\u{2b50})", "gu"];
 
 if (process.argv.includes('dev')) {
   return;
@@ -17,7 +17,7 @@ function getUserIdsFromMessage(text, regex) {
 }
 
 registerBotCommand(
-  /@!?(\d+)>\s?(\-\-)/,
+  "@!?(\d+)>\s?(\-\-)",
   () =>
     "http://media.riffsy.com/images/636a97aa416ad674eb2b72d4a6e9ad6c/tenor.gif"
 );
@@ -104,7 +104,7 @@ async function pointsBotCommand({ author, content, channel, client }) {
 
 registerBotCommand(AWARD_POINT_REGEX, pointsBotCommand);
 
-registerBotCommand(/\/points/, async function({
+registerBotCommand("/points", async function({
   content,
   client,
   channel,
@@ -123,7 +123,7 @@ registerBotCommand(/\/points/, async function({
   });
 });
 
-registerBotCommand(/\/leaderboard/, async function({ guild, content }) {
+registerBotCommand("/leaderboard", async function({ guild, content }) {
   try {
     const users = await axios.get(
       `https://odin-points-bot-discord.herokuapp.com/users`
@@ -157,7 +157,7 @@ registerBotCommand(/\/leaderboard/, async function({ guild, content }) {
   }
 });
 
-registerBotCommand(/\/setpoints/, async function({ author, content }) {
+registerBotCommand("/setpoints", async function({ author, content }) {
   if (author.id == 418918922507780096) {
     const id = content
       .split(" ")

--- a/botCommands/shrug.js
+++ b/botCommands/shrug.js
@@ -1,6 +1,6 @@
 const {registerBotCommand} = require("../botEngine.js");
 
-registerBotCommand(/\/[shurg]{5}/, ({content}) => {
+registerBotCommand("/[shurg]{5}", ({content}) => {
   function onlyUnique(value, index, self) {
     return self.indexOf(value) === index;
   }

--- a/botCommands/simpleCommands.js
+++ b/botCommands/simpleCommands.js
@@ -1,34 +1,34 @@
 const {registerBotCommand} = require('../botEngine.js');
 
-registerBotCommand(/\/hug/, () => `⊂(´・ω・｀⊂)`);
+registerBotCommand("/hug", () => `⊂(´・ω・｀⊂)`);
 
-registerBotCommand(/\/smart/, () => String.raw`f(ಠ‿↼)z`);
+registerBotCommand("/smart", () => String.raw`f(ಠ‿↼)z`);
 
-registerBotCommand(/\/lenny/, () => String.raw`( ͡° ͜ʖ ͡°)`);
+registerBotCommand("/lenny", () => String.raw`( ͡° ͜ʖ ͡°)`);
 
-registerBotCommand(/:fu:/, async (message) => {
+registerBotCommand(":fu:", async (message) => {
   await message.reply('http://media.riffsy.com/images/636a97aa416ad674eb2b72d4a6e9ad6c/tenor.gif')
   return null;
 });
 
-registerBotCommand(/\/question/, () => `**It looks like you're trying to ask a question! Please give this page a read: https://medium.com/@gordon_zhu/how-to-be-great-at-asking-questions-e37be04d0603**`);
+registerBotCommand("/question", () => `**It looks like you're trying to ask a question! Please give this page a read: https://medium.com/@gordon_zhu/how-to-be-great-at-asking-questions-e37be04d0603**`);
 
-registerBotCommand(/\/data/, () => `**Please state your question in the form of a question! https://www.dontasktoask.com/**`);
+registerBotCommand("/data", () => `**Please state your question in the form of a question! https://www.dontasktoask.com/**`);
 
-registerBotCommand(/:fu:/, ({ data }) => {
+registerBotCommand(":fu:", ({ data }) => {
   const user = data.fromUser.username;
   return `@${user} \n ![Not Nice](http://media.riffsy.com/images/636a97aa416ad674eb2b72d4a6e9ad6c/tenor.gif)`;
 });
 
-registerBotCommand(/\/sexpresso/, () => `https://i.gifer.com/8EC5.gif`);
+registerBotCommand("/sexpresso", () => `https://i.gifer.com/8EC5.gif`);
 
-registerBotCommand(/\peen/, ({author}) => {
+registerBotCommand("\peen", ({author}) => {
   if (author.id == 418918922507780096) {
     return `https://media.giphy.com/media/K5IEMtDZHxQZy/giphy.gif`;
   }
 });
 
-registerBotCommand(/\B\/google\s+.+/, ({content}) => {
+registerBotCommand("/google\s+.+", ({content}) => {
   const transform = content => {
     const query = content.split(' ').map(encodeURIComponent).join('+');
     return `**HERE YOU GO BABY >** <https://lmgtfy.com/?q=${query}>`;
@@ -37,7 +37,7 @@ registerBotCommand(/\B\/google\s+.+/, ({content}) => {
   const query = content.match(/\B\/google\s+(.+)/)[1];
   return `${transform(query)}`;
 });
-registerBotCommand(/\B\/fg\s+.+/, ({content}) => {
+registerBotCommand("/fg\s+.+", ({content}) => {
   const transform = content => {
     const query = content.split(' ').map(encodeURIComponent).join('+');
     return `**This is what you should have typed into Google >** <https://google.com/search?q=${query}>`;
@@ -48,22 +48,22 @@ registerBotCommand(/\B\/fg\s+.+/, ({content}) => {
 });
 
 
-registerBotCommand(/\/dab/, () => `https://tenor.com/view/bettywhite-dab-gif-5044603`);
+registerBotCommand("/dab", () => `https://tenor.com/view/bettywhite-dab-gif-5044603`);
 
 registerBotCommand(
-  /\/gandalf/,
+  "/gandalf",
   () => `http://emojis.slackmojis.com/emojis/images/1450458362/181/gandalf.gif`
 );
 
 
-registerBotCommand(/\/motivate/, () => {
+registerBotCommand("/motivate", () => {
   return `Don't give up! https://www.youtube.com/watch?v=KxGRhd_iWuE`;
 });
 
-registerBotCommand(/\/justdoit/, () => {
+registerBotCommand("/justdoit", () => {
   return `What are you waiting for?! https://www.youtube.com/watch?v=ZXsQAXx_ao0`;
 });
 
-registerBotCommand(/\/pairs/, () => {
+registerBotCommand("/pairs", () => {
   return `**Find your coding partner here:** https://forum.theodinproject.com/c/pairs`;
 });


### PR DESCRIPTION
This changes the `registerBotCommand` function to accept a pattern as a string or if it has modifier flags an array of strings `[pattern, modifiers]`. This will abstract the pattern logic required to find commands removed from other text.

See #37 

I don't have API keys to test it, so review would be required.

Usage:

instead of:
```js
registerBotCommand(/\/hug/ , () => `⊂(´・ω・｀⊂)`);
registerBotCommand(/<@!?(\d+)>\s?(\+\+|\u{2b50})/gu, () => {});
```
you'd use:
```js
registerBotCommand("/hug" , () => `⊂(´・ω・｀⊂)`);
registerBotCommand(["<@!?(\d+)>\s?(\+\+|\u{2b50})", "gu"], () => {});
```