### PR TITLE
use smarter regex for help command

### DIFF
--- a/botCommands/help.js
+++ b/botCommands/help.js
@@ -1,6 +1,6 @@
 const { registerBotCommand } = require('../botEngine.js');
 
-registerBotCommand(/\B\/help\b/, ({ room }) => {
+registerBotCommand(/\B\/help(\s+)?$/, ({ room }) => {
   return `
   **By posting in this chatroom you agree to our code of conduct:** <https://github.com/TheOdinProject/theodinproject/blob/master/doc/code_of_conduct.md>
 


### PR DESCRIPTION
Makes the `/help` command a bit smarter by using a different regex.

The previous `\b` at the end matched periods so `http://help.domain.com` would be matched.

New regex requires that `/help` command is at the end of the input, which I do not see to be an issue.