### PR TITLE
Chore: Add Procfile for Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: echo "I don't want a web process"
+service: npm start


### PR DESCRIPTION
Because:
* To host the bot on heroku we need to provide a procfile which tells heroku what process it should run the bot on.