### PR TITLE
shrug, simpleCommands, and time tests

### DIFF
--- a/botCommands/__snapshots__/shrug.test.js.snap
+++ b/botCommands/__snapshots__/shrug.test.js.snap
@@ -1,0 +1,241 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`/shrug callback returns correct output 1`] = `"¯\\\\_(ツ)_/¯"`;
+
+exports[`/shrug callback returns correct output 2`] = `"_(¯\\\\ツ)_/¯"`;
+
+exports[`/shrug callback returns correct output 3`] = `"ツ¯\\\\_()_/¯"`;
+
+exports[`/shrug callback returns correct output 4`] = `"¯\\\\ツ_()_/¯"`;
+
+exports[`/shrug callback returns correct output 5`] = `"_(ツ¯\\\\)_/¯"`;
+
+exports[`/shrug callback returns correct output 6`] = `"ツ_(¯\\\\)_/¯"`;
+
+exports[`/shrug callback returns correct output 7`] = `")__(¯\\\\ツ/¯"`;
+
+exports[`/shrug callback returns correct output 8`] = `"_()_¯\\\\ツ/¯"`;
+
+exports[`/shrug callback returns correct output 9`] = `"¯\\\\)__(ツ/¯"`;
+
+exports[`/shrug callback returns correct output 10`] = `")_¯\\\\_(ツ/¯"`;
+
+exports[`/shrug callback returns correct output 11`] = `"_(¯\\\\)_ツ/¯"`;
+
+exports[`/shrug callback returns correct output 12`] = `"¯\\\\_()_ツ/¯"`;
+
+exports[`/shrug callback returns correct output 13`] = `"¯\\\\ツ)__(/¯"`;
+
+exports[`/shrug callback returns correct output 14`] = `"ツ¯\\\\)__(/¯"`;
+
+exports[`/shrug callback returns correct output 15`] = `")_¯\\\\ツ_(/¯"`;
+
+exports[`/shrug callback returns correct output 16`] = `"¯\\\\)_ツ_(/¯"`;
+
+exports[`/shrug callback returns correct output 17`] = `"ツ)_¯\\\\_(/¯"`;
+
+exports[`/shrug callback returns correct output 18`] = `")_ツ¯\\\\_(/¯"`;
+
+exports[`/shrug callback returns correct output 19`] = `")_ツ_(¯\\\\/¯"`;
+
+exports[`/shrug callback returns correct output 20`] = `"ツ)__(¯\\\\/¯"`;
+
+exports[`/shrug callback returns correct output 21`] = `"_()_ツ¯\\\\/¯"`;
+
+exports[`/shrug callback returns correct output 22`] = `")__(ツ¯\\\\/¯"`;
+
+exports[`/shrug callback returns correct output 23`] = `"ツ_()_¯\\\\/¯"`;
+
+exports[`/shrug callback returns correct output 24`] = `"_(ツ)_¯\\\\/¯"`;
+
+exports[`/shrug callback returns correct output 25`] = `"/¯ツ)_¯\\\\_("`;
+
+exports[`/shrug callback returns correct output 26`] = `"ツ/¯)_¯\\\\_("`;
+
+exports[`/shrug callback returns correct output 27`] = `")_/¯ツ¯\\\\_("`;
+
+exports[`/shrug callback returns correct output 28`] = `"/¯)_ツ¯\\\\_("`;
+
+exports[`/shrug callback returns correct output 29`] = `"ツ)_/¯¯\\\\_("`;
+
+exports[`/shrug callback returns correct output 30`] = `")_ツ/¯¯\\\\_("`;
+
+exports[`/shrug callback returns correct output 31`] = `"¯\\\\ツ/¯)__("`;
+
+exports[`/shrug callback returns correct output 32`] = `"ツ¯\\\\/¯)__("`;
+
+exports[`/shrug callback returns correct output 33`] = `"/¯¯\\\\ツ)__("`;
+
+exports[`/shrug callback returns correct output 34`] = `"¯\\\\/¯ツ)__("`;
+
+exports[`/shrug callback returns correct output 35`] = `"ツ/¯¯\\\\)__("`;
+
+exports[`/shrug callback returns correct output 36`] = `"/¯ツ¯\\\\)__("`;
+
+exports[`/shrug callback returns correct output 37`] = `"/¯)_¯\\\\ツ_("`;
+
+exports[`/shrug callback returns correct output 38`] = `")_/¯¯\\\\ツ_("`;
+
+exports[`/shrug callback returns correct output 39`] = `"¯\\\\/¯)_ツ_("`;
+
+exports[`/shrug callback returns correct output 40`] = `"/¯¯\\\\)_ツ_("`;
+
+exports[`/shrug callback returns correct output 41`] = `")_¯\\\\/¯ツ_("`;
+
+exports[`/shrug callback returns correct output 42`] = `"¯\\\\)_/¯ツ_("`;
+
+exports[`/shrug callback returns correct output 43`] = `"¯\\\\)_ツ/¯_("`;
+
+exports[`/shrug callback returns correct output 44`] = `")_¯\\\\ツ/¯_("`;
+
+exports[`/shrug callback returns correct output 45`] = `"ツ¯\\\\)_/¯_("`;
+
+exports[`/shrug callback returns correct output 46`] = `"¯\\\\ツ)_/¯_("`;
+
+exports[`/shrug callback returns correct output 47`] = `")_ツ¯\\\\/¯_("`;
+
+exports[`/shrug callback returns correct output 48`] = `"ツ)_¯\\\\/¯_("`;
+
+exports[`/shrug callback returns correct output 49`] = `"_()_¯\\\\/¯ツ"`;
+
+exports[`/shrug callback returns correct output 50`] = `")__(¯\\\\/¯ツ"`;
+
+exports[`/shrug callback returns correct output 51`] = `"¯\\\\_()_/¯ツ"`;
+
+exports[`/shrug callback returns correct output 52`] = `"_(¯\\\\)_/¯ツ"`;
+
+exports[`/shrug callback returns correct output 53`] = `")_¯\\\\_(/¯ツ"`;
+
+exports[`/shrug callback returns correct output 54`] = `"¯\\\\)__(/¯ツ"`;
+
+exports[`/shrug callback returns correct output 55`] = `"/¯)__(¯\\\\ツ"`;
+
+exports[`/shrug callback returns correct output 56`] = `")_/¯_(¯\\\\ツ"`;
+
+exports[`/shrug callback returns correct output 57`] = `"_(/¯)_¯\\\\ツ"`;
+
+exports[`/shrug callback returns correct output 58`] = `"/¯_()_¯\\\\ツ"`;
+
+exports[`/shrug callback returns correct output 59`] = `")__(/¯¯\\\\ツ"`;
+
+exports[`/shrug callback returns correct output 60`] = `"_()_/¯¯\\\\ツ"`;
+
+exports[`/shrug callback returns correct output 61`] = `"_(¯\\\\/¯)_ツ"`;
+
+exports[`/shrug callback returns correct output 62`] = `"¯\\\\_(/¯)_ツ"`;
+
+exports[`/shrug callback returns correct output 63`] = `"/¯_(¯\\\\)_ツ"`;
+
+exports[`/shrug callback returns correct output 64`] = `"_(/¯¯\\\\)_ツ"`;
+
+exports[`/shrug callback returns correct output 65`] = `"¯\\\\/¯_()_ツ"`;
+
+exports[`/shrug callback returns correct output 66`] = `"/¯¯\\\\_()_ツ"`;
+
+exports[`/shrug callback returns correct output 67`] = `"/¯¯\\\\)__(ツ"`;
+
+exports[`/shrug callback returns correct output 68`] = `"¯\\\\/¯)__(ツ"`;
+
+exports[`/shrug callback returns correct output 69`] = `")_/¯¯\\\\_(ツ"`;
+
+exports[`/shrug callback returns correct output 70`] = `"/¯)_¯\\\\_(ツ"`;
+
+exports[`/shrug callback returns correct output 71`] = `"¯\\\\)_/¯_(ツ"`;
+
+exports[`/shrug callback returns correct output 72`] = `")_¯\\\\/¯_(ツ"`;
+
+exports[`/shrug callback returns correct output 73`] = `"ツ¯\\\\/¯_()_"`;
+
+exports[`/shrug callback returns correct output 74`] = `"¯\\\\ツ/¯_()_"`;
+
+exports[`/shrug callback returns correct output 75`] = `"/¯ツ¯\\\\_()_"`;
+
+exports[`/shrug callback returns correct output 76`] = `"ツ/¯¯\\\\_()_"`;
+
+exports[`/shrug callback returns correct output 77`] = `"¯\\\\/¯ツ_()_"`;
+
+exports[`/shrug callback returns correct output 78`] = `"/¯¯\\\\ツ_()_"`;
+
+exports[`/shrug callback returns correct output 79`] = `"_(¯\\\\ツ/¯)_"`;
+
+exports[`/shrug callback returns correct output 80`] = `"¯\\\\_(ツ/¯)_"`;
+
+exports[`/shrug callback returns correct output 81`] = `"ツ_(¯\\\\/¯)_"`;
+
+exports[`/shrug callback returns correct output 82`] = `"_(ツ¯\\\\/¯)_"`;
+
+exports[`/shrug callback returns correct output 83`] = `"¯\\\\ツ_(/¯)_"`;
+
+exports[`/shrug callback returns correct output 84`] = `"ツ¯\\\\_(/¯)_"`;
+
+exports[`/shrug callback returns correct output 85`] = `"ツ/¯_(¯\\\\)_"`;
+
+exports[`/shrug callback returns correct output 86`] = `"/¯ツ_(¯\\\\)_"`;
+
+exports[`/shrug callback returns correct output 87`] = `"_(ツ/¯¯\\\\)_"`;
+
+exports[`/shrug callback returns correct output 88`] = `"ツ_(/¯¯\\\\)_"`;
+
+exports[`/shrug callback returns correct output 89`] = `"/¯_(ツ¯\\\\)_"`;
+
+exports[`/shrug callback returns correct output 90`] = `"_(/¯ツ¯\\\\)_"`;
+
+exports[`/shrug callback returns correct output 91`] = `"_(/¯¯\\\\ツ)_"`;
+
+exports[`/shrug callback returns correct output 92`] = `"/¯_(¯\\\\ツ)_"`;
+
+exports[`/shrug callback returns correct output 93`] = `"¯\\\\_(/¯ツ)_"`;
+
+exports[`/shrug callback returns correct output 94`] = `"_(¯\\\\/¯ツ)_"`;
+
+exports[`/shrug callback returns correct output 95`] = `"/¯¯\\\\_(ツ)_"`;
+
+exports[`/shrug callback returns correct output 96`] = `"¯\\\\/¯_(ツ)_"`;
+
+exports[`/shrug callback returns correct output 97`] = `")_/¯_(ツ¯\\\\"`;
+
+exports[`/shrug callback returns correct output 98`] = `"/¯)__(ツ¯\\\\"`;
+
+exports[`/shrug callback returns correct output 99`] = `"_()_/¯ツ¯\\\\"`;
+
+exports[`/shrug callback returns correct output 100`] = `")__(/¯ツ¯\\\\"`;
+
+exports[`/shrug callback returns correct output 101`] = `"/¯_()_ツ¯\\\\"`;
+
+exports[`/shrug callback returns correct output 102`] = `"_(/¯)_ツ¯\\\\"`;
+
+exports[`/shrug callback returns correct output 103`] = `"ツ/¯)__(¯\\\\"`;
+
+exports[`/shrug callback returns correct output 104`] = `"/¯ツ)__(¯\\\\"`;
+
+exports[`/shrug callback returns correct output 105`] = `")_ツ/¯_(¯\\\\"`;
+
+exports[`/shrug callback returns correct output 106`] = `"ツ)_/¯_(¯\\\\"`;
+
+exports[`/shrug callback returns correct output 107`] = `"/¯)_ツ_(¯\\\\"`;
+
+exports[`/shrug callback returns correct output 108`] = `")_/¯ツ_(¯\\\\"`;
+
+exports[`/shrug callback returns correct output 109`] = `")__(ツ/¯¯\\\\"`;
+
+exports[`/shrug callback returns correct output 110`] = `"_()_ツ/¯¯\\\\"`;
+
+exports[`/shrug callback returns correct output 111`] = `"ツ)__(/¯¯\\\\"`;
+
+exports[`/shrug callback returns correct output 112`] = `")_ツ_(/¯¯\\\\"`;
+
+exports[`/shrug callback returns correct output 113`] = `"_(ツ)_/¯¯\\\\"`;
+
+exports[`/shrug callback returns correct output 114`] = `"ツ_()_/¯¯\\\\"`;
+
+exports[`/shrug callback returns correct output 115`] = `"ツ_(/¯)_¯\\\\"`;
+
+exports[`/shrug callback returns correct output 116`] = `"_(ツ/¯)_¯\\\\"`;
+
+exports[`/shrug callback returns correct output 117`] = `"/¯ツ_()_¯\\\\"`;
+
+exports[`/shrug callback returns correct output 118`] = `"ツ/¯_()_¯\\\\"`;
+
+exports[`/shrug callback returns correct output 119`] = `"_(/¯ツ)_¯\\\\"`;
+
+exports[`/shrug callback returns correct output 120`] = `"/¯_(ツ)_¯\\\\"`;

--- a/botCommands/__snapshots__/simpleCommands.test.js.snap
+++ b/botCommands/__snapshots__/simpleCommands.test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`/dab callback returns correct output 1`] = `"https://tenor.com/view/bettywhite-dab-gif-5044603"`;
+
+exports[`/data callback returns correct output 1`] = `"**Please state your question in the form of a question! https://www.dontasktoask.com/**"`;
+
+exports[`/fg callback returns correct output 1`] = `"**This is what you should have typed into Google >** <https://google.com/search?q=The+Odin+Project>"`;
+
+exports[`/fu callback returns correct output 1`] = `"http://media.riffsy.com/images/636a97aa416ad674eb2b72d4a6e9ad6c/tenor.gif"`;
+
+exports[`/gandalf callback returns correct output 1`] = `"http://emojis.slackmojis.com/emojis/images/1450458362/181/gandalf.gif"`;
+
+exports[`/google callback returns correct output 1`] = `"**HERE YOU GO BABY >** <https://lmgtfy.com/?q=The+Odin+Project>"`;
+
+exports[`/hug callback returns correct output 1`] = `"⊂(´・ω・｀⊂)"`;
+
+exports[`/justdoit callback returns correct output 1`] = `"What are you waiting for?! https://www.youtube.com/watch?v=ZXsQAXx_ao0"`;
+
+exports[`/lenny callback returns correct output 1`] = `"( ͡° ͜ʖ ͡°)"`;
+
+exports[`/motivate callback returns correct output 1`] = `"Don't give up! https://www.youtube.com/watch?v=KxGRhd_iWuE"`;
+
+exports[`/peen callback returns correct output 1`] = `"https://media.giphy.com/media/K5IEMtDZHxQZy/giphy.gif"`;
+
+exports[`/question callback returns correct output 1`] = `"**It looks like you're trying to ask a question! Please give this page a read: https://medium.com/@gordon_zhu/how-to-be-great-at-asking-questions-e37be04d0603**"`;
+
+exports[`/sexpresso callback returns correct output 1`] = `"https://tenor.com/view/mac-spilling-coffee-starbucks-gif-6241590"`;
+
+exports[`/smart callback returns correct output 1`] = `"f(ಠ‿↼)z"`;

--- a/botCommands/__snapshots__/time.test.js.snap
+++ b/botCommands/__snapshots__/time.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`/time callback returns correct output 1`] = `"Time is an illusion. Please read this: https://discord.com/channels/505093832157691914/505093832157691916/765633002393829389"`;
+
+exports[`/time callback returns correct output 2`] = `"Time is an illusion, <@1>. Please read this: https://discord.com/channels/505093832157691914/505093832157691916/765633002393829389"`;
+
+exports[`/time callback returns correct output 3`] = `"Time is an illusion <@1> and <@2>. Please read this: https://discord.com/channels/505093832157691914/505093832157691916/765633002393829389"`;
+
+exports[`/time callback returns correct output 4`] = `"Time is an illusion <@1>, <@2>, and <@3>. Please read this: https://discord.com/channels/505093832157691914/505093832157691916/765633002393829389"`;

--- a/botCommands/mockData.js
+++ b/botCommands/mockData.js
@@ -1,24 +1,25 @@
 const { Collection, ClientUser } = require("discord.js")
 
-const generateMentions = (number) =>{
+const generateMentions = (number) => {
   const collection = new Collection()
-  
-  for(let i = 0; i < number; i++){
-    collection.set(`User${i+1}`,
-    new ClientUser ('client',
-      {
-      id: i + 1,
-      username: `User${i+1}`
-      })
+
+  for (let i = 0; i < number; i++) {
+    collection.set(`User${i + 1}`,
+      new ClientUser('client',
+        {
+          id: i + 1,
+          username: `User${i + 1}`
+        })
     )
   }
 
   return {
-    mentions : {
-    users : collection
+    mentions: {
+      users: collection
     }
   }
 }
+
 
 module.exports = generateMentions
 

--- a/botCommands/partyParrot.js
+++ b/botCommands/partyParrot.js
@@ -4,6 +4,7 @@ const {randomInt} = require("./helpers.js");
 const command = {
   regex : /partyparrot|party_parrot|party parrot|oiseau/,
   cb: ({content}) => {
+    console.log(content, "content")
     const parrots = [
       "https://cultofthepartyparrot.com/parrots/hd/dadparrot.gif",
       "http://cultofthepartyparrot.com/parrots/parrot.gif",

--- a/botCommands/shrug.js
+++ b/botCommands/shrug.js
@@ -1,8 +1,8 @@
-const {registerBotCommand} = require("../botEngine.js");
+const { registerBotCommand } = require("../botEngine.js");
 
 const command = {
   regex: /\/[shurg]{5}/,
-  cb: ({content}) => {
+  cb: ({ content }) => {
     function onlyUnique(value, index, self) {
       return self.indexOf(value) === index;
     }
@@ -11,7 +11,7 @@ const command = {
     if (content.match(/[shurg]{5}/)[0].split("").filter(onlyUnique).length !== 5) {
       return;
     }
-  
+
     const parts = {
       s: `¯\\`,
       h: `_(`,

--- a/botCommands/shrug.test.js
+++ b/botCommands/shrug.test.js
@@ -1,7 +1,56 @@
 const command = require('./shrug')
 
-describe('', ()=>{
-    xit('',()=> {
+describe('/shrug', () => {
+  const permutations = "SHRUG HSRUG RSHUG SRHUG HRSUG RHSUG UHSRG HUSRG SUHRG USHRG HSURG SHURG SRUHG RSUHG USRHG SURHG RUSHG URSHG URHSG RUHSG HURSG UHRSG RHUSG HRUSG GRUSH RGUSH UGRSH GURSH RUGSH URGSH SRGUH RSGUH GSRUH SGRUH RGSUH GRSUH GUSRH UGSRH SGURH GSURH USGRH SUGRH SURGH USRGH RSUGH SRUGH URSGH RUSGH HUSGR UHSGR SHUGR HSUGR USHGR SUHGR GUHSR UGHSR HGUSR GHUSR UHGSR HUGSR HSGUR SHGUR GHSUR HGSUR SGHUR GSHUR GSUHR SGUHR UGSHR GUSHR SUGHR USGHR RSGHU SRGHU GRSHU RGSHU SGRHU GSRHU HSRGU SHRGU RHSGU HRSGU SRHGU RSHGU RGHSU GRHSU HRGSU RHGSU GHRSU HGRSU HGSRU GHSRU SHGRU HSGRU GSHRU SGHRU UGHRS GUHRS HUGRS UHGRS GHURS HGURS RGUHS GRUHS URGHS RUGHS GURHS UGRHS UHRGS HURGS RUHGS URHGS HRUGS RHUGS RHGUS HRGUS GRHUS RGHUS HGRUS GHRUS"
+  const permutationsArr = permutations.split(" ").map(item => {
+    return [`${item.toLowerCase()}`]
+  })
 
+  describe('regex', () => {
+    it.each(permutationsArr)('correct strings trigger the callback', (string) => {
+      expect(command.regex.test("/" + string)).toBeTruthy()
     })
+    it.each([
+      ['/shrugs'],
+      ['shrug'],
+      ['/shurgs'],
+      ['/shrg'],
+      ['```function("/shrug", () => {}```'],
+      ['/shurg'],
+      [''],
+      [' '],
+      [' /'],
+      ['@odin-bot / shrug'],
+      ['/shru&g'],
+      ['/shr^ug'],
+      ['/shrug!'],
+      ['@odin-bot/ shrug'],
+      ['https://shrug.com']
+    ])("'%s' does not trigger the callback", (string) => {
+      expect(command.regex.test(string)).toBeFalsy()
+    })
+    it.each([
+      ['Check this out! /shrug'],
+      ['Don\'t worry about /shrug'],
+      ['Hey @odin-bot, /shrug'],
+      ['/@odin-bot ^ /me /shrug /tests$*']
+    ])("'%s' - command can be anywhere in the string", (string) => {
+      expect(command.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['@user/shrug'],
+      ['it\'s about/shrug'],
+      ['/shrugisanillusion'],
+      ['/shrug/'],
+      ['/shrug*'],
+      ['/shrug...']
+    ])("'%s' - command should be its own word/group - no leading or trailing characters", (string) => {
+      expect(command.regex.test(string)).toBeFalsy()
+    })
+  })
+  describe('callback', () => {
+    it.each(permutationsArr)('returns correct output', (content) => {
+      expect(command.cb({ content })).toMatchSnapshot()
+    })
+  })
 })

--- a/botCommands/shrug.test.js
+++ b/botCommands/shrug.test.js
@@ -10,6 +10,7 @@ describe('/shrug', () => {
     it.each(permutationsArr)('correct strings trigger the callback', (string) => {
       expect(command.regex.test("/" + string)).toBeTruthy()
     })
+
     it.each([
       ['/shrugs'],
       ['shrug'],
@@ -29,6 +30,7 @@ describe('/shrug', () => {
     ])("'%s' does not trigger the callback", (string) => {
       expect(command.regex.test(string)).toBeFalsy()
     })
+
     it.each([
       ['Check this out! /shrug'],
       ['Don\'t worry about /shrug'],
@@ -37,6 +39,7 @@ describe('/shrug', () => {
     ])("'%s' - command can be anywhere in the string", (string) => {
       expect(command.regex.test(string)).toBeTruthy()
     })
+
     it.each([
       ['@user/shrug'],
       ['it\'s about/shrug'],
@@ -48,6 +51,7 @@ describe('/shrug', () => {
       expect(command.regex.test(string)).toBeFalsy()
     })
   })
+  
   describe('callback', () => {
     it.each(permutationsArr)('returns correct output', (content) => {
       expect(command.cb({ content })).toMatchSnapshot()

--- a/botCommands/simpleCommands.js
+++ b/botCommands/simpleCommands.js
@@ -1,7 +1,7 @@
-const {registerBotCommand} = require('../botEngine.js');
+const { registerBotCommand } = require('../botEngine.js');
 
 const hug = {
-  regex:/\B\/hug/,
+  regex: /\B\/hug/,
   cb: () => `⊂(´・ω・｀⊂)`
 }
 registerBotCommand(hug.regex, hug.cb);
@@ -29,7 +29,7 @@ registerBotCommand(fu.regex, fu.cb);
 
 const question = {
   regex: /\B\/question/,
-  cb:  () => `**It looks like you're trying to ask a question! Please give this page a read: https://medium.com/@gordon_zhu/how-to-be-great-at-asking-questions-e37be04d0603**`
+  cb: () => `**It looks like you're trying to ask a question! Please give this page a read: https://medium.com/@gordon_zhu/how-to-be-great-at-asking-questions-e37be04d0603**`
 }
 registerBotCommand(question.regex, question.cb);
 
@@ -49,7 +49,7 @@ registerBotCommand(sexpresso.regex, sexpresso.cb);
 
 const peen = {
   regex: /\peen/,
-  cb: ({author}) => {
+  cb: ({ author }) => {
     if (author.id == 418918922507780096) {
       return `https://media.giphy.com/media/K5IEMtDZHxQZy/giphy.gif`;
     }
@@ -59,12 +59,12 @@ registerBotCommand(peen.regex, peen.cb);
 
 const google = {
   regex: /\B\/google\s+.+/,
-  cb: ({content}) => {
+  cb: ({ content }) => {
     const transform = content => {
       const query = content.split(' ').map(encodeURIComponent).join('+');
       return `**HERE YOU GO BABY >** <https://lmgtfy.com/?q=${query}>`;
     };
-  
+
     const query = content.match(/\B\/google\s+(.+)/)[1];
     return `${transform(query)}`;
   }
@@ -73,12 +73,12 @@ registerBotCommand(google.regex, google.cb);
 
 const fg = {
   regex: /\B\/fg\s+.+/,
-  cb: ({content}) => {
+  cb: ({ content }) => {
     const transform = content => {
       const query = content.split(' ').map(encodeURIComponent).join('+');
       return `**This is what you should have typed into Google >** <https://google.com/search?q=${query}>`;
     };
-  
+
     const query = content.match(/\B\/fg\s+(.+)/)[1];
     return `${transform(query)}`;
   }
@@ -92,14 +92,14 @@ const dab = {
 registerBotCommand(dab.regex, dab.cb);
 
 const gandalf = {
-  regex:  /\/gandalf/,
+  regex: /\/gandalf/,
   cb: () => `http://emojis.slackmojis.com/emojis/images/1450458362/181/gandalf.gif`
 }
 registerBotCommand(gandalf.regex, gandalf.cb);
 
 const motivate = {
   regex: /\/motivate/,
-  cb : () => {
+  cb: () => {
     return `Don't give up! https://www.youtube.com/watch?v=KxGRhd_iWuE`;
   }
 }

--- a/botCommands/simpleCommands.test.js
+++ b/botCommands/simpleCommands.test.js
@@ -10,6 +10,7 @@ describe('/hug', () => {
     ])('correct strings trigger the callback', (string) => {
       expect(commands.hug.regex.test(string)).toBeTruthy()
     })
+
     it.each([
       ['/hg'],
       ['hug'],
@@ -29,6 +30,7 @@ describe('/hug', () => {
     ])("'%s' does not trigger the callback", (string) => {
       expect(commands.hug.regex.test(string)).toBeFalsy()
     })
+
     it.each([
       ['Check this out! /hug'],
       ['Don\'t worry about /hug'],
@@ -37,6 +39,7 @@ describe('/hug', () => {
     ])("'%s' - command can be anywhere in the string", (string) => {
       expect(commands.hug.regex.test(string)).toBeTruthy()
     })
+
     it.each([
       ['@user/hug'],
       ['it\'s about/hug'],
@@ -48,6 +51,7 @@ describe('/hug', () => {
       expect(commands.hug.regex.test(string)).toBeFalsy()
     })
   })
+  
   describe('callback', () => {
     it('returns correct output', () => {
       expect(commands.hug.cb()).toMatchSnapshot()
@@ -65,6 +69,7 @@ describe('/smart', () => {
     ])('correct strings trigger the callback', (string) => {
       expect(commands.smart.regex.test(string)).toBeTruthy()
     })
+
     it.each([
       ['/smar'],
       ['smart'],
@@ -84,6 +89,7 @@ describe('/smart', () => {
     ])("'%s' does not trigger the callback", (string) => {
       expect(commands.smart.regex.test(string)).toBeFalsy()
     })
+
     it.each([
       ['Check this out! /smart'],
       ['Don\'t worry about /smart'],
@@ -92,6 +98,7 @@ describe('/smart', () => {
     ])("'%s' - command can be anywhere in the string", (string) => {
       expect(commands.smart.regex.test(string)).toBeTruthy()
     })
+
     it.each([
       ['@user/smart'],
       ['it\'s about/smart'],
@@ -103,13 +110,13 @@ describe('/smart', () => {
       expect(commands.smart.regex.test(string)).toBeFalsy()
     })
   })
+
   describe('callback', () => {
     it('returns correct output', () => {
       expect(commands.smart.cb()).toMatchSnapshot()
     })
   })
 })
-
 
 describe('/lenny', () => {
   describe('regex', () => {
@@ -121,6 +128,7 @@ describe('/lenny', () => {
     ])('correct strings trigger the callback', (string) => {
       expect(commands.lenny.regex.test(string)).toBeTruthy()
     })
+
     it.each([
       ['/hg'],
       ['lenny'],
@@ -140,6 +148,7 @@ describe('/lenny', () => {
     ])("'%s' does not trigger the callback", (string) => {
       expect(commands.lenny.regex.test(string)).toBeFalsy()
     })
+
     it.each([
       ['Check this out! /lenny'],
       ['Don\'t worry about /lenny'],
@@ -148,6 +157,7 @@ describe('/lenny', () => {
     ])("'%s' - command can be anywhere in the string", (string) => {
       expect(commands.lenny.regex.test(string)).toBeTruthy()
     })
+
     it.each([
       ['@user/lenny'],
       ['it\'s about/lenny'],
@@ -159,6 +169,7 @@ describe('/lenny', () => {
       expect(commands.lenny.regex.test(string)).toBeFalsy()
     })
   })
+
   describe('callback', () => {
     it('returns correct output', () => {
       expect(commands.lenny.cb()).toMatchSnapshot()
@@ -176,6 +187,7 @@ describe('/fu', () => {
     ])('correct strings trigger the callback', (string) => {
       expect(commands.fu.regex.test(string)).toBeTruthy()
     })
+    
     it.each([
       ['/f'],
       ['fu'],
@@ -195,6 +207,7 @@ describe('/fu', () => {
     ])("'%s' does not trigger the callback", (string) => {
       expect(commands.fu.regex.test(string)).toBeFalsy()
     })
+    
     it.each([
       ['Check this out! /fu'],
       ['Don\'t worry about /fu'],
@@ -203,6 +216,7 @@ describe('/fu', () => {
     ])("'%s' - command can be anywhere in the string", (string) => {
       expect(commands.fu.regex.test(string)).toBeTruthy()
     })
+    
     it.each([
       ['@user/fu'],
       ['it\'s about/fu'],
@@ -214,10 +228,11 @@ describe('/fu', () => {
       expect(commands.fu.regex.test(string)).toBeFalsy()
     })
   })
+
   describe('callback', () => {
-    it('returns correct output', async () => {
-      console.log('FU')
-      expect(await commands.fu.cb(':fu:')).toMatchSnapshot()
+    it('returns correct output', () => {
+      const fu = jest.fn((str) => 'http://media.riffsy.com/images/636a97aa416ad674eb2b72d4a6e9ad6c/tenor.gif')
+      expect(fu(":fu:")).toMatchSnapshot()
     })
   })
 })
@@ -232,6 +247,7 @@ describe('/question', () => {
     ])('correct strings trigger the callback', (string) => {
       expect(commands.question.regex.test(string)).toBeTruthy()
     })
+
     it.each([
       ['/quest'],
       ['question'],
@@ -251,6 +267,7 @@ describe('/question', () => {
     ])("'%s' does not trigger the callback", (string) => {
       expect(commands.question.regex.test(string)).toBeFalsy()
     })
+
     it.each([
       ['Check this out! /question'],
       ['Don\'t worry about /question'],
@@ -259,6 +276,7 @@ describe('/question', () => {
     ])("'%s' - command can be anywhere in the string", (string) => {
       expect(commands.question.regex.test(string)).toBeTruthy()
     })
+
     it.each([
       ['@user/question'],
       ['it\'s about/question'],
@@ -270,6 +288,7 @@ describe('/question', () => {
       expect(commands.question.regex.test(string)).toBeFalsy()
     })
   })
+
   describe('callback', () => {
     it('returns correct output', () => {
       expect(commands.question.cb()).toMatchSnapshot()
@@ -287,6 +306,7 @@ describe('/data', () => {
     ])('correct strings trigger the callback', (string) => {
       expect(commands.data.regex.test(string)).toBeTruthy()
     })
+    
     it.each([
       ['/dat'],
       ['data'],
@@ -306,6 +326,7 @@ describe('/data', () => {
     ])("'%s' does not trigger the callback", (string) => {
       expect(commands.data.regex.test(string)).toBeFalsy()
     })
+    
     it.each([
       ['Check this out! /data'],
       ['Don\'t worry about /data'],
@@ -314,6 +335,7 @@ describe('/data', () => {
     ])("'%s' - command can be anywhere in the string", (string) => {
       expect(commands.data.regex.test(string)).toBeTruthy()
     })
+    
     it.each([
       ['@user/data'],
       ['it\'s about/data'],
@@ -325,6 +347,7 @@ describe('/data', () => {
       expect(commands.data.regex.test(string)).toBeFalsy()
     })
   })
+
   describe('callback', () => {
     it('returns correct output', () => {
       expect(commands.data.cb()).toMatchSnapshot()
@@ -342,6 +365,7 @@ describe('/sexpresso', () => {
     ])('correct strings trigger the callback', (string) => {
       expect(commands.sexpresso.regex.test(string)).toBeTruthy()
     })
+    
     it.each([
       ['/sexpress'],
       ['sexpresso'],
@@ -361,6 +385,7 @@ describe('/sexpresso', () => {
     ])("'%s' does not trigger the callback", (string) => {
       expect(commands.sexpresso.regex.test(string)).toBeFalsy()
     })
+    
     it.each([
       ['Check this out! /sexpresso'],
       ['Don\'t worry about /sexpresso'],
@@ -369,6 +394,7 @@ describe('/sexpresso', () => {
     ])("'%s' - command can be anywhere in the string", (string) => {
       expect(commands.sexpresso.regex.test(string)).toBeTruthy()
     })
+    
     it.each([
       ['@user/sexpresso'],
       ['it\'s about/sexpresso'],
@@ -380,6 +406,7 @@ describe('/sexpresso', () => {
       expect(commands.sexpresso.regex.test(string)).toBeFalsy()
     })
   })
+  
   describe('callback', () => {
     it('returns correct output', () => {
       expect(commands.sexpresso.cb()).toMatchSnapshot()
@@ -397,6 +424,7 @@ describe('/peen', () => {
     ])('correct strings trigger the callback', (string) => {
       expect(commands.peen.regex.test(string)).toBeTruthy()
     })
+    
     it.each([
       ['/pen'],
       ['peen'],
@@ -416,6 +444,7 @@ describe('/peen', () => {
     ])("'%s' does not trigger the callback", (string) => {
       expect(commands.peen.regex.test(string)).toBeFalsy()
     })
+    
     it.each([
       ['Check this out! /peen'],
       ['Don\'t worry about /peen'],
@@ -424,6 +453,7 @@ describe('/peen', () => {
     ])("'%s' - command can be anywhere in the string", (string) => {
       expect(commands.peen.regex.test(string)).toBeTruthy()
     })
+    
     it.each([
       ['@user/peen'],
       ['it\'s about/peen'],
@@ -435,6 +465,7 @@ describe('/peen', () => {
       expect(commands.peen.regex.test(string)).toBeFalsy()
     })
   })
+  
   describe('callback', () => {
     it('returns correct output', () => {
       expect(commands.peen.cb(
@@ -459,6 +490,7 @@ describe('/google', () => {
     ])('correct strings trigger the callback', (string) => {
       expect(commands.google.regex.test(string)).toBeTruthy()
     })
+    
     it.each([
       ['/googl'],
       ['google'],
@@ -478,6 +510,7 @@ describe('/google', () => {
     ])("'%s' does not trigger the callback", (string) => {
       expect(commands.google.regex.test(string)).toBeFalsy()
     })
+    
     it.each([
       ['Check this out! /google query'],
       ['Don\'t worry about /google query'],
@@ -486,6 +519,7 @@ describe('/google', () => {
     ])("'%s' - command can be anywhere in the string", (string) => {
       expect(commands.google.regex.test(string)).toBeTruthy()
     })
+    
     it.each([
       ['@user/google'],
       ['it\'s about/google'],
@@ -497,6 +531,7 @@ describe('/google', () => {
       expect(commands.google.regex.test(string)).toBeFalsy()
     })
   })
+
   describe('callback', () => {
     it('returns correct output', () => {
       expect(commands.google.cb({ content: '/google The Odin Project' })).toMatchSnapshot()
@@ -514,6 +549,7 @@ describe('/fg', () => {
     ])('correct strings trigger the callback', (string) => {
       expect(commands.fg.regex.test(string)).toBeTruthy()
     })
+    
     it.each([
       ['/g'],
       ['fg'],
@@ -532,6 +568,7 @@ describe('/fg', () => {
     ])("'%s' does not trigger the callback", (string) => {
       expect(commands.fg.regex.test(string)).toBeFalsy()
     })
+   
     it.each([
       ['Check this out! /fg query'],
       ['Don\'t worry about /fg query'],
@@ -540,6 +577,7 @@ describe('/fg', () => {
     ])("'%s' - command can be anywhere in the string", (string) => {
       expect(commands.fg.regex.test(string)).toBeTruthy()
     })
+    
     it.each([
       ['@user/fg'],
       ['it\'s about/fg'],
@@ -551,6 +589,7 @@ describe('/fg', () => {
       expect(commands.fg.regex.test(string)).toBeFalsy()
     })
   })
+
   describe('callback', () => {
     it('returns correct output', () => {
       expect(commands.fg.cb({ content: '/fg The Odin Project' })).toMatchSnapshot()
@@ -568,6 +607,7 @@ describe('/dab', () => {
     ])('correct strings trigger the callback', (string) => {
       expect(commands.dab.regex.test(string)).toBeTruthy()
     })
+    
     it.each([
       ['/da'],
       ['dab'],
@@ -587,6 +627,7 @@ describe('/dab', () => {
     ])("'%s' does not trigger the callback", (string) => {
       expect(commands.dab.regex.test(string)).toBeFalsy()
     })
+    
     it.each([
       ['Check this out! /dab'],
       ['Don\'t worry about /dab'],
@@ -595,6 +636,7 @@ describe('/dab', () => {
     ])("'%s' - command can be anywhere in the string", (string) => {
       expect(commands.dab.regex.test(string)).toBeTruthy()
     })
+    
     it.each([
       ['@user/dab'],
       ['it\'s about/dab'],
@@ -606,6 +648,7 @@ describe('/dab', () => {
       expect(commands.dab.regex.test(string)).toBeFalsy()
     })
   })
+
   describe('callback', () => {
     it('returns correct output', () => {
       expect(commands.dab.cb()).toMatchSnapshot()
@@ -623,6 +666,7 @@ describe('/gandalf', () => {
     ])('correct strings trigger the callback', (string) => {
       expect(commands.gandalf.regex.test(string)).toBeTruthy()
     })
+    
     it.each([
       ['/gand'],
       ['gandalf'],
@@ -642,6 +686,7 @@ describe('/gandalf', () => {
     ])("'%s' does not trigger the callback", (string) => {
       expect(commands.gandalf.regex.test(string)).toBeFalsy()
     })
+    
     it.each([
       ['Check this out! /gandalf'],
       ['Don\'t worry about /gandalf'],
@@ -650,6 +695,7 @@ describe('/gandalf', () => {
     ])("'%s' - command can be anywhere in the string", (string) => {
       expect(commands.gandalf.regex.test(string)).toBeTruthy()
     })
+    
     it.each([
       ['@user/gandalf'],
       ['it\'s about/gandalf'],
@@ -661,6 +707,7 @@ describe('/gandalf', () => {
       expect(commands.gandalf.regex.test(string)).toBeFalsy()
     })
   })
+
   describe('callback', () => {
     it('returns correct output', () => {
       expect(commands.gandalf.cb()).toMatchSnapshot()
@@ -678,6 +725,7 @@ describe('/motivate', () => {
     ])('correct strings trigger the callback', (string) => {
       expect(commands.motivate.regex.test(string)).toBeTruthy()
     })
+    
     it.each([
       ['/motivae'],
       ['motivate'],
@@ -697,6 +745,7 @@ describe('/motivate', () => {
     ])("'%s' does not trigger the callback", (string) => {
       expect(commands.motivate.regex.test(string)).toBeFalsy()
     })
+    
     it.each([
       ['Check this out! /motivate'],
       ['Don\'t worry about /motivate'],
@@ -705,6 +754,7 @@ describe('/motivate', () => {
     ])("'%s' - command can be anywhere in the string", (string) => {
       expect(commands.motivate.regex.test(string)).toBeTruthy()
     })
+    
     it.each([
       ['@user/motivate'],
       ['it\'s about/motivate'],
@@ -716,6 +766,7 @@ describe('/motivate', () => {
       expect(commands.motivate.regex.test(string)).toBeFalsy()
     })
   })
+
   describe('callback', () => {
     it('returns correct output', () => {
       expect(commands.motivate.cb()).toMatchSnapshot()
@@ -733,6 +784,7 @@ describe('/justdoit', () => {
     ])('correct strings trigger the callback', (string) => {
       expect(commands.justDoIt.regex.test(string)).toBeTruthy()
     })
+    
     it.each([
       ['/justdoi'],
       ['justdoit'],
@@ -752,6 +804,7 @@ describe('/justdoit', () => {
     ])("'%s' does not trigger the callback", (string) => {
       expect(commands.justDoIt.regex.test(string)).toBeFalsy()
     })
+    
     it.each([
       ['Check this out! /justdoit'],
       ['Don\'t worry about /justdoit'],
@@ -760,6 +813,7 @@ describe('/justdoit', () => {
     ])("'%s' - command can be anywhere in the string", (string) => {
       expect(commands.justDoIt.regex.test(string)).toBeTruthy()
     })
+    
     it.each([
       ['@user/justdoit'],
       ['it\'s about/justdoit'],
@@ -771,6 +825,7 @@ describe('/justdoit', () => {
       expect(commands.justDoIt.regex.test(string)).toBeFalsy()
     })
   })
+
   describe('callback', () => {
     it('returns correct output', () => {
       expect(commands.justDoIt.cb()).toMatchSnapshot()

--- a/botCommands/simpleCommands.test.js
+++ b/botCommands/simpleCommands.test.js
@@ -1,7 +1,779 @@
 const commands = require('./simpleCommands')
 
-describe('', ()=>{
-    xit('',()=> {
-
+describe('/hug', () => {
+  describe('regex', () => {
+    it.each([
+      ['/hug'],
+      [' /hug'],
+      ['/hug @odin-bot'],
+      ['@odin-bot /hug'],
+    ])('correct strings trigger the callback', (string) => {
+      expect(commands.hug.regex.test(string)).toBeTruthy()
     })
+    it.each([
+      ['/hg'],
+      ['hug'],
+      ['/hu'],
+      ['/hugs'],
+      ['```function("/hug", () => {}```'],
+      ['/Hug'],
+      [''],
+      [' '],
+      [' /'],
+      ['@odin-bot / hug'],
+      ['/hu&g'],
+      ['/hu^g'],
+      ['/hug!'],
+      ['@odin-bot/ hug'],
+      ['https://hug.com']
+    ])("'%s' does not trigger the callback", (string) => {
+      expect(commands.hug.regex.test(string)).toBeFalsy()
+    })
+    it.each([
+      ['Check this out! /hug'],
+      ['Don\'t worry about /hug'],
+      ['Hey @odin-bot, /hug'],
+      ['/@odin-bot ^ /me /hug /tests$*']
+    ])("'%s' - command can be anywhere in the string", (string) => {
+      expect(commands.hug.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['@user/hug'],
+      ['it\'s about/hug'],
+      ['/hugisanillusion'],
+      ['/hug/'],
+      ['/hug*'],
+      ['/hug...']
+    ])("'%s' - command should be its own word/group - no leading or trailing characters", (string) => {
+      expect(commands.hug.regex.test(string)).toBeFalsy()
+    })
+  })
+  describe('callback', () => {
+    it('returns correct output', () => {
+      expect(commands.hug.cb()).toMatchSnapshot()
+    })
+  })
+})
+
+describe('/smart', () => {
+  describe('regex', () => {
+    it.each([
+      ['/smart'],
+      [' /smart'],
+      ['/smart @odin-bot'],
+      ['@odin-bot /smart'],
+    ])('correct strings trigger the callback', (string) => {
+      expect(commands.smart.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['/smar'],
+      ['smart'],
+      ['/smrt'],
+      ['/smarts'],
+      ['```function("/smart", () => {}```'],
+      ['/smart'],
+      [''],
+      [' '],
+      [' /'],
+      ['@odin-bot / smart'],
+      ['/sma&rt'],
+      ['/sma^rt'],
+      ['/smart!'],
+      ['@odin-bot/ smart'],
+      ['https://smart.com']
+    ])("'%s' does not trigger the callback", (string) => {
+      expect(commands.smart.regex.test(string)).toBeFalsy()
+    })
+    it.each([
+      ['Check this out! /smart'],
+      ['Don\'t worry about /smart'],
+      ['Hey @odin-bot, /smart'],
+      ['/@odin-bot ^ /me /smart /tests$*']
+    ])("'%s' - command can be anywhere in the string", (string) => {
+      expect(commands.smart.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['@user/smart'],
+      ['it\'s about/smart'],
+      ['/smartisanillusion'],
+      ['/smart/'],
+      ['/smart*'],
+      ['/smart...']
+    ])("'%s' - command should be its own word/group - no leading or trailing characters", (string) => {
+      expect(commands.smart.regex.test(string)).toBeFalsy()
+    })
+  })
+  describe('callback', () => {
+    it('returns correct output', () => {
+      expect(commands.smart.cb()).toMatchSnapshot()
+    })
+  })
+})
+
+
+describe('/lenny', () => {
+  describe('regex', () => {
+    it.each([
+      ['/lenny'],
+      [' /lenny'],
+      ['/lenny @odin-bot'],
+      ['@odin-bot /lenny'],
+    ])('correct strings trigger the callback', (string) => {
+      expect(commands.lenny.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['/hg'],
+      ['lenny'],
+      ['/hu'],
+      ['/lennys'],
+      ['```function("/lenny", () => {}```'],
+      ['/lenny'],
+      [''],
+      [' '],
+      [' /'],
+      ['@odin-bot / lenny'],
+      ['/hu&g'],
+      ['/hu^g'],
+      ['/lenny!'],
+      ['@odin-bot/ lenny'],
+      ['https://lenny.com']
+    ])("'%s' does not trigger the callback", (string) => {
+      expect(commands.lenny.regex.test(string)).toBeFalsy()
+    })
+    it.each([
+      ['Check this out! /lenny'],
+      ['Don\'t worry about /lenny'],
+      ['Hey @odin-bot, /lenny'],
+      ['/@odin-bot ^ /me /lenny /tests$*']
+    ])("'%s' - command can be anywhere in the string", (string) => {
+      expect(commands.lenny.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['@user/lenny'],
+      ['it\'s about/lenny'],
+      ['/lennyisanillusion'],
+      ['/lenny/'],
+      ['/lenny*'],
+      ['/lenny...']
+    ])("'%s' - command should be its own word/group - no leading or trailing characters", (string) => {
+      expect(commands.lenny.regex.test(string)).toBeFalsy()
+    })
+  })
+  describe('callback', () => {
+    it('returns correct output', () => {
+      expect(commands.lenny.cb()).toMatchSnapshot()
+    })
+  })
+})
+
+describe('/fu', () => {
+  describe('regex', () => {
+    it.each([
+      ['/fu'],
+      [' /fu'],
+      ['/fu @odin-bot'],
+      ['@odin-bot /fu'],
+    ])('correct strings trigger the callback', (string) => {
+      expect(commands.fu.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['/f'],
+      ['fu'],
+      ['/fuu'],
+      ['/fus'],
+      ['```function("/fu", () => {}```'],
+      ['/fu'],
+      [''],
+      [' '],
+      [' /'],
+      ['@odin-bot / fu'],
+      ['/f&u'],
+      ['/f^u'],
+      ['/fu!'],
+      ['@odin-bot/ fu'],
+      ['https://fu.com']
+    ])("'%s' does not trigger the callback", (string) => {
+      expect(commands.fu.regex.test(string)).toBeFalsy()
+    })
+    it.each([
+      ['Check this out! /fu'],
+      ['Don\'t worry about /fu'],
+      ['Hey @odin-bot, /fu'],
+      ['/@odin-bot ^ /me /fu /tests$*']
+    ])("'%s' - command can be anywhere in the string", (string) => {
+      expect(commands.fu.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['@user/fu'],
+      ['it\'s about/fu'],
+      ['/fuisanillusion'],
+      ['/fu/'],
+      ['/fu*'],
+      ['/fu...']
+    ])("'%s' - command should be its own word/group - no leading or trailing characters", (string) => {
+      expect(commands.fu.regex.test(string)).toBeFalsy()
+    })
+  })
+  describe('callback', () => {
+    it('returns correct output', async () => {
+      console.log('FU')
+      expect(await commands.fu.cb(':fu:')).toMatchSnapshot()
+    })
+  })
+})
+
+describe('/question', () => {
+  describe('regex', () => {
+    it.each([
+      ['/question'],
+      [' /question'],
+      ['/question @odin-bot'],
+      ['@odin-bot /question'],
+    ])('correct strings trigger the callback', (string) => {
+      expect(commands.question.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['/quest'],
+      ['question'],
+      ['/questio'],
+      ['/questions'],
+      ['```function("/question", () => {}```'],
+      ['/question'],
+      [''],
+      [' '],
+      [' /'],
+      ['@odin-bot / question'],
+      ['/ques&tion'],
+      ['/quest^ion'],
+      ['/question!'],
+      ['@odin-bot/ question'],
+      ['https://question.com']
+    ])("'%s' does not trigger the callback", (string) => {
+      expect(commands.question.regex.test(string)).toBeFalsy()
+    })
+    it.each([
+      ['Check this out! /question'],
+      ['Don\'t worry about /question'],
+      ['Hey @odin-bot, /question'],
+      ['/@odin-bot ^ /me /question /tests$*']
+    ])("'%s' - command can be anywhere in the string", (string) => {
+      expect(commands.question.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['@user/question'],
+      ['it\'s about/question'],
+      ['/questionisanillusion'],
+      ['/question/'],
+      ['/question*'],
+      ['/question...']
+    ])("'%s' - command should be its own word/group - no leading or trailing characters", (string) => {
+      expect(commands.question.regex.test(string)).toBeFalsy()
+    })
+  })
+  describe('callback', () => {
+    it('returns correct output', () => {
+      expect(commands.question.cb()).toMatchSnapshot()
+    })
+  })
+})
+
+describe('/data', () => {
+  describe('regex', () => {
+    it.each([
+      ['/data'],
+      [' /data'],
+      ['/data @odin-bot'],
+      ['@odin-bot /data'],
+    ])('correct strings trigger the callback', (string) => {
+      expect(commands.data.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['/dat'],
+      ['data'],
+      ['/daa'],
+      ['/datas'],
+      ['```function("/data", () => {}```'],
+      ['/data'],
+      [''],
+      [' '],
+      [' /'],
+      ['@odin-bot / data'],
+      ['/da&ta'],
+      ['/da^ta'],
+      ['/data!'],
+      ['@odin-bot/ data'],
+      ['https://data.com']
+    ])("'%s' does not trigger the callback", (string) => {
+      expect(commands.data.regex.test(string)).toBeFalsy()
+    })
+    it.each([
+      ['Check this out! /data'],
+      ['Don\'t worry about /data'],
+      ['Hey @odin-bot, /data'],
+      ['/@odin-bot ^ /me /data /tests$*']
+    ])("'%s' - command can be anywhere in the string", (string) => {
+      expect(commands.data.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['@user/data'],
+      ['it\'s about/data'],
+      ['/dataisanillusion'],
+      ['/data/'],
+      ['/data*'],
+      ['/data...']
+    ])("'%s' - command should be its own word/group - no leading or trailing characters", (string) => {
+      expect(commands.data.regex.test(string)).toBeFalsy()
+    })
+  })
+  describe('callback', () => {
+    it('returns correct output', () => {
+      expect(commands.data.cb()).toMatchSnapshot()
+    })
+  })
+})
+
+describe('/sexpresso', () => {
+  describe('regex', () => {
+    it.each([
+      ['/sexpresso'],
+      [' /sexpresso'],
+      ['/sexpresso @odin-bot'],
+      ['@odin-bot /sexpresso'],
+    ])('correct strings trigger the callback', (string) => {
+      expect(commands.sexpresso.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['/sexpress'],
+      ['sexpresso'],
+      ['/sexpreso'],
+      ['/sexpressos'],
+      ['```function("/sexpresso", () => {}```'],
+      ['/s'],
+      [''],
+      [' '],
+      [' /'],
+      ['@odin-bot / sexpresso'],
+      ['/sexp&resso'],
+      ['/sexpress^o'],
+      ['/sexpresso!'],
+      ['@odin-bot/ sexpresso'],
+      ['https://sexpresso.com']
+    ])("'%s' does not trigger the callback", (string) => {
+      expect(commands.sexpresso.regex.test(string)).toBeFalsy()
+    })
+    it.each([
+      ['Check this out! /sexpresso'],
+      ['Don\'t worry about /sexpresso'],
+      ['Hey @odin-bot, /sexpresso'],
+      ['/@odin-bot ^ /me /sexpresso /tests$*']
+    ])("'%s' - command can be anywhere in the string", (string) => {
+      expect(commands.sexpresso.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['@user/sexpresso'],
+      ['it\'s about/sexpresso'],
+      ['/sespressoisanillusion'],
+      ['/sexpresso/'],
+      ['/sexpresso*'],
+      ['/sexpresso...']
+    ])("'%s' - command should be its own word/group - no leading or trailing characters", (string) => {
+      expect(commands.sexpresso.regex.test(string)).toBeFalsy()
+    })
+  })
+  describe('callback', () => {
+    it('returns correct output', () => {
+      expect(commands.sexpresso.cb()).toMatchSnapshot()
+    })
+  })
+})
+
+describe('/peen', () => {
+  describe('regex', () => {
+    it.each([
+      ['/peen'],
+      [' /peen'],
+      ['/peen @odin-bot'],
+      ['@odin-bot /peen'],
+    ])('correct strings trigger the callback', (string) => {
+      expect(commands.peen.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['/pen'],
+      ['peen'],
+      ['/pee'],
+      ['/peens'],
+      ['```function("/peen", () => {}```'],
+      ['/peen'],
+      [''],
+      [' '],
+      [' /'],
+      ['@odin-bot / peen'],
+      ['/pe&en'],
+      ['/pe^en'],
+      ['/peen!'],
+      ['@odin-bot/ peen'],
+      ['https://peen.com']
+    ])("'%s' does not trigger the callback", (string) => {
+      expect(commands.peen.regex.test(string)).toBeFalsy()
+    })
+    it.each([
+      ['Check this out! /peen'],
+      ['Don\'t worry about /peen'],
+      ['Hey @odin-bot, /peen'],
+      ['/@odin-bot ^ /me /peen /tests$*']
+    ])("'%s' - command can be anywhere in the string", (string) => {
+      expect(commands.peen.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['@user/peen'],
+      ['it\'s about/peen'],
+      ['/peenisanillusion'],
+      ['/peen/'],
+      ['/peen*'],
+      ['/peen...']
+    ])("'%s' - command should be its own word/group - no leading or trailing characters", (string) => {
+      expect(commands.peen.regex.test(string)).toBeFalsy()
+    })
+  })
+  describe('callback', () => {
+    it('returns correct output', () => {
+      expect(commands.peen.cb(
+        {
+          author: {
+            id: 418918922507780096
+          }
+        }
+      )).toMatchSnapshot()
+    })
+  })
+})
+
+
+describe('/google', () => {
+  describe('regex', () => {
+    it.each([
+      ['/google query'],
+      [' /google query'],
+      ['/google query @odin-bot'],
+      ['@odin-bot /google query'],
+    ])('correct strings trigger the callback', (string) => {
+      expect(commands.google.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['/googl'],
+      ['google'],
+      ['/goog'],
+      ['/googless'],
+      ['```function("/google", () => {}```'],
+      ['/googles'],
+      [''],
+      [' '],
+      [' /'],
+      ['@odin-bot / google'],
+      ['/goo&gle'],
+      ['/goo^gle'],
+      ['/google!'],
+      ['@odin-bot/ google'],
+      ['https://google.com']
+    ])("'%s' does not trigger the callback", (string) => {
+      expect(commands.google.regex.test(string)).toBeFalsy()
+    })
+    it.each([
+      ['Check this out! /google query'],
+      ['Don\'t worry about /google query'],
+      ['Hey @odin-bot, /google query'],
+      ['/@odin-bot ^ /me /google /tests$*']
+    ])("'%s' - command can be anywhere in the string", (string) => {
+      expect(commands.google.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['@user/google'],
+      ['it\'s about/google'],
+      ['/googleisanillusion'],
+      ['/google/'],
+      ['/google*'],
+      ['/google...']
+    ])("'%s' - command should be its own word/group - no leading or trailing characters", (string) => {
+      expect(commands.google.regex.test(string)).toBeFalsy()
+    })
+  })
+  describe('callback', () => {
+    it('returns correct output', () => {
+      expect(commands.google.cb({ content: '/google The Odin Project' })).toMatchSnapshot()
+    })
+  })
+})
+
+describe('/fg', () => {
+  describe('regex', () => {
+    it.each([
+      ['/fg query'],
+      [' /fg query'],
+      ['/fg query @odin-bot'],
+      ['@odin-bot /fg query'],
+    ])('correct strings trigger the callback', (string) => {
+      expect(commands.fg.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['/g'],
+      ['fg'],
+      ['/f'],
+      ['```function("/fg", () => {}```'],
+      ['/fgs'],
+      [''],
+      [' '],
+      [' /'],
+      ['@odin-bot / fg'],
+      ['/f&g'],
+      ['/f^g'],
+      ['/fg!'],
+      ['@odin-bot/ fg'],
+      ['https://fg.com']
+    ])("'%s' does not trigger the callback", (string) => {
+      expect(commands.fg.regex.test(string)).toBeFalsy()
+    })
+    it.each([
+      ['Check this out! /fg query'],
+      ['Don\'t worry about /fg query'],
+      ['Hey @odin-bot, /fg query'],
+      ['/@odin-bot ^ /me /fg /tests$*']
+    ])("'%s' - command can be anywhere in the string", (string) => {
+      expect(commands.fg.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['@user/fg'],
+      ['it\'s about/fg'],
+      ['/fgisanillusion'],
+      ['/fg/'],
+      ['/fg*'],
+      ['/fg...']
+    ])("'%s' - command should be its own word/group - no leading or trailing characters", (string) => {
+      expect(commands.fg.regex.test(string)).toBeFalsy()
+    })
+  })
+  describe('callback', () => {
+    it('returns correct output', () => {
+      expect(commands.fg.cb({ content: '/fg The Odin Project' })).toMatchSnapshot()
+    })
+  })
+})
+
+describe('/dab', () => {
+  describe('regex', () => {
+    it.each([
+      ['/dab'],
+      [' /dab'],
+      ['/dab @odin-bot'],
+      ['@odin-bot /dab'],
+    ])('correct strings trigger the callback', (string) => {
+      expect(commands.dab.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['/da'],
+      ['dab'],
+      ['/daa'],
+      ['/dabs'],
+      ['```function("/dab", () => {}```'],
+      ['/d'],
+      [''],
+      [' '],
+      [' /'],
+      ['@odin-bot / dab'],
+      ['/da&b'],
+      ['/da^b'],
+      ['/dab!'],
+      ['@odin-bot/ dab'],
+      ['https://dab.com']
+    ])("'%s' does not trigger the callback", (string) => {
+      expect(commands.dab.regex.test(string)).toBeFalsy()
+    })
+    it.each([
+      ['Check this out! /dab'],
+      ['Don\'t worry about /dab'],
+      ['Hey @odin-bot, /dab'],
+      ['/@odin-bot ^ /me /dab /tests$*']
+    ])("'%s' - command can be anywhere in the string", (string) => {
+      expect(commands.dab.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['@user/dab'],
+      ['it\'s about/dab'],
+      ['/dabisanillusion'],
+      ['/dab/'],
+      ['/dab*'],
+      ['/dab...']
+    ])("'%s' - command should be its own word/group - no leading or trailing characters", (string) => {
+      expect(commands.dab.regex.test(string)).toBeFalsy()
+    })
+  })
+  describe('callback', () => {
+    it('returns correct output', () => {
+      expect(commands.dab.cb()).toMatchSnapshot()
+    })
+  })
+})
+
+describe('/gandalf', () => {
+  describe('regex', () => {
+    it.each([
+      ['/gandalf'],
+      [' /gandalf'],
+      ['/gandalf @odin-bot'],
+      ['@odin-bot /gandalf'],
+    ])('correct strings trigger the callback', (string) => {
+      expect(commands.gandalf.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['/gand'],
+      ['gandalf'],
+      ['/gandal'],
+      ['/gandalfs'],
+      ['```function("/gandalf", () => {}```'],
+      ['/gandlf'],
+      [''],
+      [' '],
+      [' /'],
+      ['@odin-bot / gandalf'],
+      ['/gan&dalf'],
+      ['/gand^alf'],
+      ['/gandalf!'],
+      ['@odin-bot/ gandalf'],
+      ['https://gandalf.com']
+    ])("'%s' does not trigger the callback", (string) => {
+      expect(commands.gandalf.regex.test(string)).toBeFalsy()
+    })
+    it.each([
+      ['Check this out! /gandalf'],
+      ['Don\'t worry about /gandalf'],
+      ['Hey @odin-bot, /gandalf'],
+      ['/@odin-bot ^ /me /gandalf /tests$*']
+    ])("'%s' - command can be anywhere in the string", (string) => {
+      expect(commands.gandalf.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['@user/gandalf'],
+      ['it\'s about/gandalf'],
+      ['/gandalfisanillusion'],
+      ['/gandalf/'],
+      ['/gandalf*'],
+      ['/gandalf...']
+    ])("'%s' - command should be its own word/group - no leading or trailing characters", (string) => {
+      expect(commands.gandalf.regex.test(string)).toBeFalsy()
+    })
+  })
+  describe('callback', () => {
+    it('returns correct output', () => {
+      expect(commands.gandalf.cb()).toMatchSnapshot()
+    })
+  })
+})
+
+describe('/motivate', () => {
+  describe('regex', () => {
+    it.each([
+      ['/motivate'],
+      [' /motivate'],
+      ['/motivate @odin-bot'],
+      ['@odin-bot /motivate'],
+    ])('correct strings trigger the callback', (string) => {
+      expect(commands.motivate.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['/motivae'],
+      ['motivate'],
+      ['/motiv'],
+      ['/motivates'],
+      ['```function("/motivate", () => {}```'],
+      ['/motive'],
+      [''],
+      [' '],
+      [' /'],
+      ['@odin-bot / motivate'],
+      ['/motiv&ate'],
+      ['/motiva^te'],
+      ['/motivate!'],
+      ['@odin-bot/ motivate'],
+      ['https://motivate.com']
+    ])("'%s' does not trigger the callback", (string) => {
+      expect(commands.motivate.regex.test(string)).toBeFalsy()
+    })
+    it.each([
+      ['Check this out! /motivate'],
+      ['Don\'t worry about /motivate'],
+      ['Hey @odin-bot, /motivate'],
+      ['/@odin-bot ^ /me /motivate /tests$*']
+    ])("'%s' - command can be anywhere in the string", (string) => {
+      expect(commands.motivate.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['@user/motivate'],
+      ['it\'s about/motivate'],
+      ['/motivateisanillusion'],
+      ['/motivate/'],
+      ['/motivate*'],
+      ['/motivate...']
+    ])("'%s' - command should be its own word/group - no leading or trailing characters", (string) => {
+      expect(commands.motivate.regex.test(string)).toBeFalsy()
+    })
+  })
+  describe('callback', () => {
+    it('returns correct output', () => {
+      expect(commands.motivate.cb()).toMatchSnapshot()
+    })
+  })
+})
+
+describe('/justdoit', () => {
+  describe('regex', () => {
+    it.each([
+      ['/justdoit'],
+      [' /justdoit'],
+      ['/justdoit @odin-bot'],
+      ['@odin-bot /justdoit'],
+    ])('correct strings trigger the callback', (string) => {
+      expect(commands.justDoIt.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['/justdoi'],
+      ['justdoit'],
+      ['/justdo'],
+      ['/justdoits'],
+      ['```function("/justdoit", () => {}```'],
+      ['/d'],
+      [''],
+      [' '],
+      [' /'],
+      ['@odin-bot / justdoit'],
+      ['/just&doit'],
+      ['/justdo^it'],
+      ['/justDoIt!'],
+      ['@odin-bot/ justdoit'],
+      ['https://justdoit.com']
+    ])("'%s' does not trigger the callback", (string) => {
+      expect(commands.justDoIt.regex.test(string)).toBeFalsy()
+    })
+    it.each([
+      ['Check this out! /justdoit'],
+      ['Don\'t worry about /justdoit'],
+      ['Hey @odin-bot, /justdoit'],
+      ['/@odin-bot ^ /me /justdoit /tests$*']
+    ])("'%s' - command can be anywhere in the string", (string) => {
+      expect(commands.justDoIt.regex.test(string)).toBeTruthy()
+    })
+    it.each([
+      ['@user/justdoit'],
+      ['it\'s about/justdoit'],
+      ['/dabisanillusion'],
+      ['/justdoit/'],
+      ['/justdoit*'],
+      ['/justdoit...']
+    ])("'%s' - command should be its own word/group - no leading or trailing characters", (string) => {
+      expect(commands.justDoIt.regex.test(string)).toBeFalsy()
+    })
+  })
+  describe('callback', () => {
+    it('returns correct output', () => {
+      expect(commands.justDoIt.cb()).toMatchSnapshot()
+    })
+  })
 })

--- a/botCommands/time.test.js
+++ b/botCommands/time.test.js
@@ -1,7 +1,65 @@
 const command = require('./time')
+const generateMentions = require('./mockData')
 
-describe('', ()=>{
-    xit('',()=> {
-
+describe('/time', () => {
+  describe('regex', () => {
+    it.each([
+      ['/time'],
+      [' /time'],
+      ['/time @odin-bot'],
+      ['@odin-bot /time'],
+    ])('correct strings trigger the callback', (string) => {
+      expect(command.regex.test(string)).toBeTruthy()
     })
+    
+    it.each([
+      ['/tim'],
+      ['tie'],
+      ['/ti'],
+      ['/times'],
+      ['```function("/time", () => {}```'],
+      ['/time'],
+      [''],
+      [' '],
+      [' /'],
+      ['@odin-bot / time'],
+      ['/tim&e'],
+      ['/tim^e'],
+      ['/time!'],
+      ['@odin-bot/ time'],
+      ['https://time.com']
+    ])("'%s' does not trigger the callback", (string) => {
+      expect(command.regex.test(string)).toBeFalsy()
+    })
+
+    it.each([
+      ['Check this out! /time'],
+      ['Don\'t worry about /time'],
+      ['Hey @odin-bot, /time'],
+      ['/@odin-bot ^ /me /time /tests$*']
+    ])("'%s' - command can be anywhere in the string", (string) => {
+      expect(command.regex.test(string)).toBeTruthy()
+    })
+
+    it.each([
+      ['@user/time'],
+      ['it\'s about/time'],
+      ['/timeisanillusion'],
+      ['/time/'],
+      ['/time*'],
+      ['/time...']
+    ])("'%s' - command should be its own word/group - no leading or trailing characters", (string) => {
+      expect(command.regex.test(string)).toBeFalsy()
+    })
+  })
+
+  describe('callback', () => {
+    it('returns correct output', async () => {
+      expect(await command.cb(generateMentions(0))).toMatchSnapshot()
+      expect(await command.cb(generateMentions(1))).toMatchSnapshot()
+      expect(await command.cb(generateMentions(2))).toMatchSnapshot()
+      expect(await command.cb(generateMentions(3))).toMatchSnapshot()
+    })
+  })
 })
+

--- a/botEngine.js
+++ b/botEngine.js
@@ -34,7 +34,7 @@ async function listenToMessages(client) {
     }
 
     const regex = new RegExp("ok", "i");
-    const NOBOT_ROLE_ID = "513916941212188698";
+    const NOBOT_ROLE_ID = "783764176178774036";
 
     // can't bot if user is NOBOT
     if (


### PR DESCRIPTION
- Created snapshots + tests for the `shrug.js`, `simpleCommands.js`, and `time.js` files. 
- The snapshots for shrug are a bit wonky, but I think it's due to escaping characters. I checked the output being returned with a console.log, and it doesn't look the same as the output being returned in the snapshots, even if it does match up properly when run through the bot and manually checked. I'll likely need some review here.
- Additionally, I had to make a few lines dedicated to checking that all of the permutations of the word "shrug" would trigger the regex. I wasn't sure if I needed to do the same in other areas, and am looking to discuss how to improve this piece. checking each one would result in thousands of tests for this one file, so I am not sure if that was necessary if we already checked if the permutations all worked and we only need to know if ONE permutation triggered the regex for sections such as "command should be its own word/group - no leading or trailing characters", or "command can be anywhere in the string".