### PR TITLE
add windows command

### DIFF
--- a/botCommands/__snapshots__/windows.test.js.snap
+++ b/botCommands/__snapshots__/windows.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`/windows callback returns correct output 1`] = `"The Odin Project does not support Windows, WSL, or any OS outside of our recommendations. We are happy to assist with any questions about installing a VM or dual booting Linux. https://www.theodinproject.com/courses/foundations/lessons/installation-overview#os-options "`;

--- a/botCommands/windows.js
+++ b/botCommands/windows.js
@@ -1,0 +1,12 @@
+const { registerBotCommand } = require("../botEngine.js");
+
+const command = {
+  regex: /(?<!\S)\/windows(?!\S)/,
+  cb: () => { 
+    return `The Odin Project does not support Windows, WSL, or any OS outside of our recommendations. We are happy to assist with any questions about installing a VM or dual booting Linux. https://www.theodinproject.com/courses/foundations/lessons/installation-overview#os-options `
+  },
+};
+
+registerBotCommand(command.regex, command.cb);
+
+module.exports = command;

--- a/botCommands/windows.test.js
+++ b/botCommands/windows.test.js
@@ -1,0 +1,52 @@
+const command = require('./windows')
+
+describe('/windows', () => {
+  describe('regex', () => {
+    it.each([
+      ['/windows'],
+      [' /windows'],
+      ['/windows @odin-bot'],
+      ['@odin-bot /windows'],
+    ])('correct strings trigger the callback', (string) => {
+      expect(command.regex.test(string)).toBeTruthy()
+    })
+    
+    it.each([
+     ["wndows"],
+     ["windows"],
+     ["window"],
+     ["/wndows"],
+     ["/window"],
+     ["/ windows"],
+     ["/awindows"]
+    ])("'%s' does not trigger the callback", (string) => {
+      expect(command.regex.test(string)).toBeFalsy()
+    })
+
+    it.each([
+      ['Check this out! /windows'],
+      ['Don\'t worry about /windows'],
+      ['Hey @odin-bot, /windows'],
+      ['/@odin-bot ^ /me /windows /tests$*']
+    ])("'%s' - command can be anywhere in the string", (string) => {
+      expect(command.regex.test(string)).toBeTruthy()
+    })
+
+    it.each([
+      ['@user/windows'],
+      ['it\'s about/windows'],
+      ['/windowsanillusion'],
+      ['/windows/'],
+      ['/windows*'],
+      ['/windows...']
+    ])("'%s' - command should be its own word/group - no leading or trailing characters", (string) => {
+      expect(command.regex.test(string)).toBeFalsy()
+    })
+  })
+
+  describe('callback', () => {
+    it('returns correct output', () => {
+      expect(command.cb()).toMatchSnapshot()
+    })
+  })
+})


### PR DESCRIPTION
- add windows command affirming our recommendations in the curriculum
- NOTE: The pre-push hook was bypassed using `--no-verify` due to other commands failing the regex portion. 
<img width="854" alt="Screen Shot 2021-01-22 at 9 08 20 AM" src="https://user-images.githubusercontent.com/22967723/105521963-7d789580-5c91-11eb-9e01-cb0a719221a5.png">
