### PR TITLE
add issue and PR templates for the odin bot

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,12 @@
+<!--
+Thanks for your interest in the Odin Bot. As a courtesy to our maintainers please do a search in our issues to make sure this is not a duplicate of an existing issue. In order to get issues addressed in a reasonable amount of time, we request that you include a baseline of information about the issue you're experiencing and how to reproduce it. Please provide the following:
+-->
+
+#### 1. List the command and describe the nature of the problem you're experiencing:
+
+...your issue
+
+#### 2. If the issue is related to the rendering or content of a command, please include a screenshot.
+
+...screenshot if needed
+

--- a/.github/ISSUE_TEMPLATE/COMMAND_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/COMMAND_REQUEST.md
@@ -1,0 +1,11 @@
+<!--
+Thanks for your interest in the Odin Bot. As a courtesy to our maintainers please do a search in our issues to make sure this is not a duplicate of a command requested in an existing issue. In order to get these requested addressed in a reasonable amount of time, we request that you include a baseline of information about the command you are requesting. Please note that commands are not guaranteed to be added. Please provide the following:
+-->
+
+#### 1. Describe the nature of the command you'd like to be added:
+
+#### 2. How can this improve or benefit the Odin Discord?
+
+#### 3. What text should trigger the command? (e.g. `/commandName`, `/commandName @mention`)
+
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!-- 
+Thanks for your interest in The Odin Project's Odin Bot. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
+-->
+
+ - [ ] You have read the [Odin Bot README/Contributing Guide](https://github.com/TheOdinProject/odin-bot-v2/blob/master/README.md).
+
+#### 1.Describe the changes made:
+
+... Your text here
+
+
+#### 2. If this PR modifies a command, please provide a screenshot of the passing tests below. NOTE: Your PR will not be merged if you have any failing test cases. 
+
+... Image here
+
+
+
+#### 3. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:
+
+#XXXXX


### PR DESCRIPTION
Adds a `.github` directory that includes Issues and PR templates, and closes #102.