### PR TITLE
Extend /debug command to add "JS" and "Ruby" commands.

### DIFF
--- a/botCommands/__snapshots__/debug.test.js.snap
+++ b/botCommands/__snapshots__/debug.test.js.snap
@@ -1,18 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`/debug js should return the correct output 1`] = `
-"Based on the description of your problem, you can get to the root of it using a debugger. Learning how to track down problems like this is an inevitable part of being a developer.
-<https://developers.google.com/web/tools/chrome-devtools/javascript>"
+"
+          Based on the description of your problem, you can get to the root of it using a debugger. Learning how to track down problems like this is an inevitable part of being a developer.
+<https://developers.google.com/web/tools/chrome-devtools/javascript>
+        "
 `;
 
 exports[`/debug rb should return the correct output 1`] = `
-"Based on the description of your problem, you can get to the root of it using a debugger. Learning how to track down problems like this is an inevitable part of being a developer.
-<https://www.theodinproject.com/courses/ruby-programming/lessons/debugging#debugging-with-pry-byebug>"
+"
+          Based on the description of your problem, you can get to the root of it using a debugger. Learning how to track down problems like this is an inevitable part of being a developer. 
+<https://www.theodinproject.com/courses/ruby-programming/lessons/debugging#debugging-with-pry-byebug>
+        "
 `;
 
 exports[`/debug should return the correct output 1`] = `
 "Based on the description of your problem, you can get to the root of it using a debugger. Learning how to track down problems like this is an inevitable part of being a developer.
 <https://en.wikipedia.org/wiki/Debugging>
 
-To get a helpful resource in javascript or ruby, run \`/debug js\` or \`/debug rb\`."
+To get a language specific resource on Javascript or Ruby, run \`/debug js\` or \`/debug rb\`."
 `;

--- a/botCommands/__snapshots__/debug.test.js.snap
+++ b/botCommands/__snapshots__/debug.test.js.snap
@@ -1,3 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`/debug callback should return the correct output 1`] = `"Looks like this problem can be solved using a debugger: <https://developers.google.com/web/tools/chrome-devtools/javascript>"`;
+exports[`/debug js should return the correct output 1`] = `
+"Based on the description of your problem, you can get to the root of it using a debugger. Learning how to track down problems like this is an inevitable part of being a developer.
+<https://developers.google.com/web/tools/chrome-devtools/javascript>"
+`;
+
+exports[`/debug rb should return the correct output 1`] = `
+"Based on the description of your problem, you can get to the root of it using a debugger. Learning how to track down problems like this is an inevitable part of being a developer.
+<https://www.theodinproject.com/courses/ruby-programming/lessons/debugging#debugging-with-pry-byebug>"
+`;
+
+exports[`/debug should return the correct output 1`] = `
+"Based on the description of your problem, you can get to the root of it using a debugger. Learning how to track down problems like this is an inevitable part of being a developer.
+<https://en.wikipedia.org/wiki/Debugging>
+
+To get a helpful resource in javascript or ruby, run \`/debug js\` or \`/debug rb\`."
+`;

--- a/botCommands/debug.js
+++ b/botCommands/debug.js
@@ -7,25 +7,22 @@ const command = {
 
     const template = `Based on the description of your problem, you can get to the root of it using a debugger. Learning how to track down problems like this is an inevitable part of being a developer.`;
 
-    const defaultReply =
-      template +
-      `\n<https://en.wikipedia.org/wiki/Debugging>
-
-To get a helpful resource in javascript or ruby, run \`/debug js\` or \`/debug rb\`.`;
-
     switch (query) {
       case "js":
-        return (
-          template +
-          `\n<https://developers.google.com/web/tools/chrome-devtools/javascript>`
-        );
+        return `
+          ${template}
+<https://developers.google.com/web/tools/chrome-devtools/javascript>
+        `;
       case "rb":
-        return (
-          template +
-          `\n<https://www.theodinproject.com/courses/ruby-programming/lessons/debugging#debugging-with-pry-byebug>`
-        );
+        return `
+          ${template} 
+<https://www.theodinproject.com/courses/ruby-programming/lessons/debugging#debugging-with-pry-byebug>
+        `;
       default:
-        return defaultReply;
+        return `${template}
+<https://en.wikipedia.org/wiki/Debugging>
+
+To get a language specific resource on Javascript or Ruby, run \`/debug js\` or \`/debug rb\`.`;
     }
   },
 };

--- a/botCommands/debug.js
+++ b/botCommands/debug.js
@@ -2,8 +2,32 @@ const { registerBotCommand } = require("../botEngine.js");
 
 const command = {
   regex: /(?<!\S)\/debug(?!\S)/,
-  cb: () =>
-    `Looks like this problem can be solved using a debugger: <https://developers.google.com/web/tools/chrome-devtools/javascript>`,
+  cb: ({ content }) => {
+    const query = content.match(/\B\/debug\s?(\S+)?/)[1];
+
+    const template = `Based on the description of your problem, you can get to the root of it using a debugger. Learning how to track down problems like this is an inevitable part of being a developer.`;
+
+    const defaultReply =
+      template +
+      `\n<https://en.wikipedia.org/wiki/Debugging>
+
+To get a helpful resource in javascript or ruby, run \`/debug js\` or \`/debug rb\`.`;
+
+    switch (query) {
+      case "js":
+        return (
+          template +
+          `\n<https://developers.google.com/web/tools/chrome-devtools/javascript>`
+        );
+      case "rb":
+        return (
+          template +
+          `\n<https://www.theodinproject.com/courses/ruby-programming/lessons/debugging#debugging-with-pry-byebug>`
+        );
+      default:
+        return defaultReply;
+    }
+  },
 };
 
 registerBotCommand(command.regex, command.cb);

--- a/botCommands/debug.test.js
+++ b/botCommands/debug.test.js
@@ -6,6 +6,14 @@ describe("/debug", () => {
     [" /debug"],
     ["/debug @odin-bot"],
     [" /debug @odin-bot"],
+    ["/debug js"],
+    ["/debug rb"],
+    [" /debug js"],
+    [" /debug rb"],
+    ["/debug js @odin-bot"],
+    ["/debug rb @odin-bot"],
+    [" /debug js @odin-bot"],
+    [" /debug rb @odin-bot"],
   ])("'%s' triggers the callback", (string) => {
     expect(command.regex.test(string)).toBeTruthy();
   });
@@ -53,8 +61,20 @@ describe("/debug", () => {
   );
 });
 
-describe("/debug callback", () => {
+describe("/debug", () => {
   it("should return the correct output", () => {
-    expect(command.cb()).toMatchSnapshot();
+    expect(command.cb({ content: "/debug" })).toMatchSnapshot();
+  });
+});
+
+describe("/debug js", () => {
+  it("should return the correct output", () => {
+    expect(command.cb({ content: "/debug js" })).toMatchSnapshot();
+  });
+});
+
+describe("/debug rb", () => {
+  it("should return the correct output", () => {
+    expect(command.cb({ content: "/debug rb" })).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
<!-- 
Thanks for your interest in The Odin Project's Odin Bot. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read the [Odin Bot README/Contributing Guide](https://github.com/TheOdinProject/odin-bot-v2/blob/master/README.md).

#### 1.Describe the changes made:

Extended `/debug` command to accept `js` and `rb` arguments and give out appropriate debugging articles.


#### 2. If this PR modifies a command, please provide a screenshot of the passing tests below. NOTE: Your PR will not be merged if you have any failing test cases. 

![tests](https://user-images.githubusercontent.com/54525741/107683070-26317800-6cc7-11eb-916d-066d9818796c.png)




#### 3. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#105 
