### PR TITLE
Fix addPoints command regex

### DIFF
--- a/botCommands/__snapshots__/points.test.js.snap
+++ b/botCommands/__snapshots__/points.test.js.snap
@@ -55,36 +55,36 @@ exports[`/leaderboard callback returns correct output 8`] = `
 "
 `;
 
-exports[`<@!123456789> ++ callback returns correct output for a single user entering club-40 1`] = `"HEYYY EVERYONE SAY HI TO <@2> the newest member of CLUB 40"`;
-
-exports[`<@!123456789> ++ callback returns correct output for a single user entering club-40 2`] = `"Woot! <@2> now has 40 points"`;
-
-exports[`<@!123456789> ++ callback returns correct output for a single user w/o club-40 1`] = `"Sweet! <@2> now has 21 points"`;
-
-exports[`<@!123456789> ++ callback returns correct output for a user mentioning Odin Bot 1`] = `"awwwww shucks... :heart_eyes:"`;
-
-exports[`<@!123456789> ++ callback returns correct output for a user mentioning themselves 1`] = `"http://media0.giphy.com/media/RddAJiGxTPQFa/200.gif"`;
-
-exports[`<@!123456789> ++ callback returns correct output for a user mentioning themselves 2`] = `"You can't do that!"`;
-
-exports[`<@!123456789> ++ callback returns correct output for more than five mentioned users 1`] = `"you can only do 5 at a time..... "`;
-
-exports[`<@!123456789> ++ callback returns correct output for more than five mentioned users 2`] = `"Sweet! <@2> now has 11 points"`;
-
-exports[`<@!123456789> ++ callback returns correct output for more than five mentioned users 3`] = `"Nice! <@2> now has 4 points"`;
-
-exports[`<@!123456789> ++ callback returns correct output for more than five mentioned users 4`] = `"Nice! <@2> now has 2 points"`;
-
-exports[`<@!123456789> ++ callback returns correct output for more than five mentioned users 5`] = `"Nice! <@2> now has 1 point"`;
-
-exports[`<@!123456789> ++ callback returns correct output for more than five mentioned users 6`] = `"Sweet! <@2> now has 22 points"`;
-
-exports[`<@!123456789> ++ callback returns correct output for up to five mentioned users 1`] = `"Woot! <@2> now has 34 points"`;
-
-exports[`<@!123456789> ++ callback returns correct output for up to five mentioned users 2`] = `"Sweet! <@2> now has 22 points"`;
-
-exports[`<@!123456789> ++ callback returns correct output for up to five mentioned users 3`] = `"Nice! <@2> now has 3 points"`;
-
-exports[`<@!123456789> ++ callback returns correct output for up to five mentioned users 4`] = `"Nice! <@2> now has 1 point"`;
-
 exports[`@user -- callback returns correct output 1`] = `"http://media.riffsy.com/images/636a97aa416ad674eb2b72d4a6e9ad6c/tenor.gif"`;
+
+exports[`award points callback returns correct output for a single user entering club-40 1`] = `"HEYYY EVERYONE SAY HI TO <@2> the newest member of CLUB 40"`;
+
+exports[`award points callback returns correct output for a single user entering club-40 2`] = `"Woot! <@2> now has 40 points"`;
+
+exports[`award points callback returns correct output for a single user w/o club-40 1`] = `"Sweet! <@2> now has 21 points"`;
+
+exports[`award points callback returns correct output for a user mentioning Odin Bot 1`] = `"awwwww shucks... :heart_eyes:"`;
+
+exports[`award points callback returns correct output for a user mentioning themselves 1`] = `"http://media0.giphy.com/media/RddAJiGxTPQFa/200.gif"`;
+
+exports[`award points callback returns correct output for a user mentioning themselves 2`] = `"You can't do that!"`;
+
+exports[`award points callback returns correct output for more than five mentioned users 1`] = `"you can only do 5 at a time..... "`;
+
+exports[`award points callback returns correct output for more than five mentioned users 2`] = `"Sweet! <@2> now has 11 points"`;
+
+exports[`award points callback returns correct output for more than five mentioned users 3`] = `"Nice! <@2> now has 4 points"`;
+
+exports[`award points callback returns correct output for more than five mentioned users 4`] = `"Nice! <@2> now has 2 points"`;
+
+exports[`award points callback returns correct output for more than five mentioned users 5`] = `"Nice! <@2> now has 1 point"`;
+
+exports[`award points callback returns correct output for more than five mentioned users 6`] = `"Sweet! <@2> now has 22 points"`;
+
+exports[`award points callback returns correct output for up to five mentioned users 1`] = `"Woot! <@2> now has 34 points"`;
+
+exports[`award points callback returns correct output for up to five mentioned users 2`] = `"Sweet! <@2> now has 22 points"`;
+
+exports[`award points callback returns correct output for up to five mentioned users 3`] = `"Nice! <@2> now has 3 points"`;
+
+exports[`award points callback returns correct output for up to five mentioned users 4`] = `"Nice! <@2> now has 1 point"`;

--- a/botCommands/points.js
+++ b/botCommands/points.js
@@ -2,7 +2,7 @@ const axios = require('axios');
 const config = require('../config.js');
 const { registerBotCommand } = require('../botEngine.js');
 
-const AWARD_POINT_REGEX = /<@!?(\d+)>\s?(\+\+|\u{2b50})/gu;
+const AWARD_POINT_REGEX = /(?<!\S)<@!?(\d+)>\s?(\+\+|\u{2b50})(?!\S)/gu;
 
 axios.defaults.headers.post.Authorization = `Token ${config.pointsbot.token}`;
 
@@ -37,7 +37,7 @@ async function lookUpUser(discord_id) {
       `https://theodinproject.com/api/points/${discord_id}`,
     );
     return pointsBotResponse.data;
-  } catch (err) {}
+  } catch (err) { }
 }
 
 function exclamation(points) {
@@ -61,8 +61,14 @@ function plural(points) {
   return points === 1 ? 'point' : 'points';
 }
 
+const userRegex = '<@!?(\\d+)>';
+const starRegex = '\u{2b50}';
+const plusRegex = '(\\+\\+)';
+
 const awardPoints = {
-  regex: /(?<!\S)<@!?(\d+)>\s?(\+\+)(?!\S)/,
+  // uses a negative lookback to isolate the command
+  // followed by the Discord User, a whitespace character and either the star or plus incrementer
+  regex: new RegExp(`(?<!\\S)${userRegex}\\s?(${plusRegex}|${starRegex})(?!\\S)`, 'gu'),
   cb: async function pointsBotCommand({
     author,
     content,
@@ -109,8 +115,7 @@ const awardPoints = {
               }
             }
             channel.send(
-              `${exclamation(pointsUser.points)} ${user} now has ${
-                pointsUser.points
+              `${exclamation(pointsUser.points)} ${user} now has ${pointsUser.points
               } ${plural(pointsUser.points)}`,
             );
           }
@@ -140,7 +145,7 @@ const points = {
         if (userPoints) {
           channel.send(`${username} has ${userPoints.points} points!`);
         }
-      } catch (err) {}
+      } catch (err) { }
     });
   },
 };
@@ -172,9 +177,8 @@ const leaderboard = {
             : undefined;
           if (username) {
             if (i == 0) {
-              usersList += `${i + 1} - ${username} [${
-                user.points
-              } points] :tada: \n`;
+              usersList += `${i + 1} - ${username} [${user.points
+                } points] :tada: \n`;
             } else {
               usersList += `${i + 1} - ${username} [${user.points} points] \n`;
             }

--- a/botCommands/points.test.js
+++ b/botCommands/points.test.js
@@ -51,14 +51,13 @@ beforeEach(() => {
   User.mockClear();
 });
 
-describe('<@!123456789> ++', () => {
-  describe('regex', () => {
+describe('award points', () => {
+  describe('regex ++', () => {
     it.each([
       ['<@!123456789> ++'],
       ['thanks <@!123456789> ++'],
-      ['<@!123456789>++'],
-    ])('correct strings trigger the callback', (string) => {
-      expect(commands.awardPoints.regex.test(string)).toBeTruthy();
+    ])("%s' - triggers the callback", (string) => {
+      expect(string.match(commands.awardPoints.regex)).toBeTruthy();
     });
 
     it.each([
@@ -70,29 +69,73 @@ describe('<@!123456789> ++', () => {
       ['/++'],
       ['```function("<@!123456789> ++", () => {}```'],
     ])("'%s' does not trigger the callback", (string) => {
-      expect(commands.awardPoints.regex.test(string)).toBeFalsy();
+      expect(string.match(commands.awardPoints.regex)).toBeFalsy();
     });
 
     it.each([
       ['Check this out! <@!123456789> ++'],
       ["Don't worry about it <@!123456789> ++"],
       ['Hey <@!123456789> ++'],
-      ['/ <@!123456789>++ ^ /me /leaderboard /tests$*'],
+      ['/ <@!123456789> ++ ^ /me /leaderboard /tests$*'],
     ])("'%s' - command can be anywhere in the string", (string) => {
-      expect(commands.awardPoints.regex.test(string)).toBeTruthy();
+      expect(string.match(commands.awardPoints.regex)).toBeTruthy();
+    });
+
+    it.each([
+      ['@user/ ++'],
+      ["it's about/<@!123456789> ++"],
+      ['<@!123456789> ++isanillusion'],
+      ['<@!123456789> ++/'],
+      ['<@!123456789> ++*'],
+      ['<@!123456789> ++...'],
+    ])(
+      "'%s' - command should be its own word/group - no leading or trailing characters",
+      (string) => {
+        expect(string.match(commands.awardPoints.regex)).toBeFalsy();
+      },
+    );
+  });
+
+  describe('regex ⭐', () => {
+    it.each([
+      ['<@!123456789> ⭐'],
+      ['thanks <@!123456789> ⭐'],
+    ])("'%s' - correct strings trigger the callback", (string) => {
+      expect(string.match(commands.awardPoints.regex)).toBeTruthy();
+    });
+
+    it.each([
+      ['⭐'],
+      [''],
+      [' '],
+      [' /'],
+      ['odin-bot⭐'],
+      ['/⭐'],
+      ['```function("<@!123456789> ⭐", () => {}```'],
+    ])("'%s' does not trigger the callback", (string) => {
+      expect(string.match(commands.awardPoints.regex)).toBeFalsy();
+    });
+
+    it.each([
+      ['Check this out! <@!123456789> ⭐'],
+      ["Don't worry about it <@!123456789> ⭐"],
+      ['Hey <@!123456789> ⭐'],
+      ['/ <@!123456789> ⭐ ^ /me /leaderboard /tests$*'],
+    ])("'%s' - command can be anywhere in the string", (string) => {
+      expect(string.match(commands.awardPoints.regex)).toBeTruthy();
     });
 
     it.each([
       ['@user/++'],
-      ["it's about/<@!123456789>++"],
-      ['<@!123456789>++isanillusion'],
-      ['<@!123456789>++/'],
-      ['<@!123456789>++*'],
-      ['<@!123456789>++...'],
+      ["it's about/<@!123456789> ⭐"],
+      ['<@!123456789> ⭐isanillusion'],
+      ['<@!123456789> ⭐/'],
+      ['<@!123456789> ⭐*'],
+      ['<@!123456789> ⭐...'],
     ])(
       "'%s' - command should be its own word/group - no leading or trailing characters",
       (string) => {
-        expect(commands.awardPoints.regex.test(string)).toBeFalsy();
+        expect(string.match(commands.awardPoints.regex)).toBeFalsy();
       },
     );
   });


### PR DESCRIPTION
<!-- 
Thanks for your interest in The Odin Project's Odin Bot. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [X] You have read the [Odin Bot README/Contributing Guide](https://github.com/TheOdinProject/odin-bot-v2/blob/master/README.md).

#### 1.Describe the changes made:

The regex now uses a `RegExp()` constructor that allows us to break the complex regex into distinct pieces, such as the Discord username, and our incrementing matchers like the star and ++. The star matcher now works correctly once more. 

A bug was found in the tests due to the behavior of `RegExp.test()` and `lastIndex`, so the tests now use `String.match()` so we can get an accurate result. The tests now also include cases for our star matcher. 

NOTE:  I had to push using --no-verify due to ESLint issues, but will fix the repository and make a separate PR so our master branch will now be ESLint compliant and contributors will not be met with unrelated issues when attempting to push their changes.


#### 2. If this PR modifies a command, please provide a screenshot of the passing tests below. NOTE: Your PR will not be merged if you have any failing test cases. 

<img width="382" alt="Screen Shot 2021-02-25 at 9 22 33 AM" src="https://user-images.githubusercontent.com/22967723/109192708-6c1d2000-774c-11eb-9e02-f5f134d32f16.png">



#### 3. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

Closes #107 
