### PR TITLE
chore: remove #i-didnt-read-the-rules msg listener

### DIFF
--- a/botEngine.js
+++ b/botEngine.js
@@ -48,19 +48,7 @@ async function listenToMessages(client) {
       return;
     }
 
-    if (
-      message.channel.id === '693255421607280670' &&
-      message.member.roles.find(role => role.name === 'loki?')
-    ) {
-      if (regex.test(message)) {
-        message.channel.send(`Hello there, ${message.author}! It seems you misunderstood our instructions. Please return to <#693244715839127653> and read carefully.`);
-      }
-      else {
-        message.channel.send(`Hello ${message.author}! If you haven't yet, go read the <#693244715839127653> for instructions on how to access the rest of our discord server.
-If you are still having trouble after following the instructions, DM a Maintainer or Core member.`);
-      }
-      return;
-    } else if (message.channel.id === '627445384297316352') { // creations-showcase
+    if (message.channel.id === '627445384297316352') { // creations-showcase
       if (creationsMessage) {
         creationsMessage.delete()
       }


### PR DESCRIPTION
Our Discord community now uses the membership screening feature built-in to Discord, removing the need for odin-bot to respond to user messages in the "I-didnt-read-the-rules" channel.

This commit:
- Removes the associated code for the channel message listener.