### PR TITLE
Removed 5 of 7 warnings by disabling the eslint console rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,5 +11,7 @@
   "parserOptions": {
     "ecmaVersion": 12
   },
-  "rules": {}
+  "rules": {
+    "no-console": "off"
+  }
 }


### PR DESCRIPTION
 - [x] You have read the [Odin Bot README/Contributing Guide](https://github.com/TheOdinProject/odin-bot-v2/blob/master/README.md).

#### 1.Describe the changes made:

I Removed 5 of 7 warnings by disabling the eslint console rule. Another option would be to change console.log out with console.error or console.warn.


#### 2. If this PR modifies a command, please provide a screenshot of the passing tests below. NOTE: Your PR will not be merged if you have any failing test cases. 

... Image here



#### 3. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#116
