### PR TITLE
Fix /faq to use URL

### DIFF
--- a/botCommands/__snapshots__/faq.test.js.snap
+++ b/botCommands/__snapshots__/faq.test.js.snap
@@ -4,7 +4,7 @@ exports[`callback should return the correct output 1`] = `
 Object {
   "author": null,
   "color": 13407555,
-  "description": "**The definition of insanity is answering the same question over and over again when we have an <#823266307293839401>!  Help us stay sane by giving it a read.**",
+  "description": "**The definition of insanity is answering the same question over and over again when we have an [#faq](https://discord.com/channels/505093832157691914/823266307293839401/823266549912829992)!  Help us stay sane by giving it a read.**",
   "fields": Array [],
   "footer": null,
   "image": null,
@@ -20,7 +20,7 @@ exports[`callback should return the correct output 2`] = `
 Object {
   "author": null,
   "color": 13407555,
-  "description": "**The definition of insanity is answering the same question over and over again when we have an <#823266307293839401>! <@1>, help us stay sane by giving it a read.**",
+  "description": "**The definition of insanity is answering the same question over and over again when we have an [#faq](https://discord.com/channels/505093832157691914/823266307293839401/823266549912829992)! <@1>, help us stay sane by giving it a read.**",
   "fields": Array [],
   "footer": null,
   "image": null,
@@ -36,7 +36,7 @@ exports[`callback should return the correct output 3`] = `
 Object {
   "author": null,
   "color": 13407555,
-  "description": "**The definition of insanity is answering the same question over and over again when we have an <#823266307293839401>! <@1> and <@2>, help us stay sane by giving it a read.**",
+  "description": "**The definition of insanity is answering the same question over and over again when we have an [#faq](https://discord.com/channels/505093832157691914/823266307293839401/823266549912829992)! <@1> and <@2>, help us stay sane by giving it a read.**",
   "fields": Array [],
   "footer": null,
   "image": null,
@@ -52,7 +52,7 @@ exports[`callback should return the correct output 4`] = `
 Object {
   "author": null,
   "color": 13407555,
-  "description": "**The definition of insanity is answering the same question over and over again when we have an <#823266307293839401>! <@1>, <@2>, and <@3>, help us stay sane by giving it a read.**",
+  "description": "**The definition of insanity is answering the same question over and over again when we have an [#faq](https://discord.com/channels/505093832157691914/823266307293839401/823266549912829992)! <@1>, <@2>, and <@3>, help us stay sane by giving it a read.**",
   "fields": Array [],
   "footer": null,
   "image": null,

--- a/botCommands/faq.js
+++ b/botCommands/faq.js
@@ -1,10 +1,10 @@
-const Discord = require('discord.js');
-const { registerBotCommand } = require('../botEngine.js');
+const Discord = require("discord.js");
+const { registerBotCommand } = require("../botEngine.js");
 
 const command = {
   regex: /(?<!\S)\/faq(?!\S)/,
   cb: async ({ mentions }) => {
-    let users = '';
+    let users = "";
     const mentionedUsers = mentions.users.array();
     if (mentionedUsers.length >= 3) {
       mentionedUsers.forEach((user, index) => {
@@ -31,8 +31,8 @@ const command = {
       .setTitle('Frequently Asked Questions')
       .setDescription(
         !users
-          ? '**The definition of insanity is answering the same question over and over again when we have an <#823266307293839401>!  Help us stay sane by giving it a read.**'
-          : `**The definition of insanity is answering the same question over and over again when we have an <#823266307293839401>!${users}, help us stay sane by giving it a read.**`,
+          ? '**The definition of insanity is answering the same question over and over again when we have an [#faq](https://discord.com/channels/505093832157691914/823266307293839401/823266549912829992)!  Help us stay sane by giving it a read.**'
+          : `**The definition of insanity is answering the same question over and over again when we have an [#faq](https://discord.com/channels/505093832157691914/823266307293839401/823266549912829992)!${users}, help us stay sane by giving it a read.**`
       );
 
     return faqCommandEmbed;

--- a/botCommands/faq.js
+++ b/botCommands/faq.js
@@ -1,10 +1,10 @@
-const Discord = require("discord.js");
-const { registerBotCommand } = require("../botEngine.js");
+const Discord = require('discord.js');
+const { registerBotCommand } = require('../botEngine.js');
 
 const command = {
   regex: /(?<!\S)\/faq(?!\S)/,
   cb: async ({ mentions }) => {
-    let users = "";
+    let users = '';
     const mentionedUsers = mentions.users.array();
     if (mentionedUsers.length >= 3) {
       mentionedUsers.forEach((user, index) => {
@@ -32,7 +32,7 @@ const command = {
       .setDescription(
         !users
           ? '**The definition of insanity is answering the same question over and over again when we have an [#faq](https://discord.com/channels/505093832157691914/823266307293839401/823266549912829992)!  Help us stay sane by giving it a read.**'
-          : `**The definition of insanity is answering the same question over and over again when we have an [#faq](https://discord.com/channels/505093832157691914/823266307293839401/823266549912829992)!${users}, help us stay sane by giving it a read.**`
+          : `**The definition of insanity is answering the same question over and over again when we have an [#faq](https://discord.com/channels/505093832157691914/823266307293839401/823266549912829992)!${users}, help us stay sane by giving it a read.**`,
       );
 
     return faqCommandEmbed;


### PR DESCRIPTION
<!-- 
Thanks for your interest in The Odin Project's Odin Bot. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read the [Odin Bot README/Contributing Guide](https://github.com/TheOdinProject/odin-bot-v2/blob/master/README.md).

#### 1.Describe the changes made:

Changed the `/faq` embed to use URL of #faq channel instead of Channel Id.

**Reason:** The `#faq` link was not clickable in Android Phones.


#### 2. If this PR modifies a command, please provide a screenshot of the passing tests below. NOTE: Your PR will not be merged if you have any failing test cases. 

![test](https://user-images.githubusercontent.com/54525741/113487338-24b94a80-94d5-11eb-924c-bace7ad4dd55.png)




#### 3. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

No
