### PR TITLE
update circleci node orb to  5.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  node: circleci/node@3.0.0
+  node: circleci/node@5.0.0
 
 jobs:
   tests-and-linters:


### PR DESCRIPTION
This commit:
- Updates node orb version to the most recent, 5.0.0
