### PR TITLE
fix: fetch members on startup for cache integrity

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,10 +9,16 @@ glob.sync('./botCommands/**/*.js', { ignore: './botCommands/**/*.test.js' }).for
   require(`${path.resolve(file)}`); // eslint-disable-line global-require, import/no-dynamic-require
 });
 
-const client = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES] });
+const client = new Client({
+  intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES, Intents.FLAGS.GUILD_MEMBERS],
+});
 
-client.once('ready', () => {
+client.once('ready', async () => {
   console.log('Bot session started:', new Date());
+
+  // Fetch Guild members on startup to ensure the integrity of the cache
+  const guild = await client.guilds.fetch('480223680803110924');
+  await guild.members.fetch();
 });
 
 listenToMessages(client);


### PR DESCRIPTION
Problem:
The `/leaderboard` command was returning a leaderboard that was missing members that exist in our points table in the database. This is due to us fetching members from the cache (which is not always reliable or up to date).

This commit:
- Adds the GUILD_MEMBERS intent such that the bot can fetch members (as it is required to listen to certain events as well, such as a member joining or leaving)
- Fetches all members of the discord on startup, such that the cache for the current bot session is up to date.

