### PR TITLE
add discord guild id to env var

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,3 @@
 POINTSBOT_TOKEN=xxxxx
 DISCORD_API_KEY=xxxxxxxx
+DISCORD_GUILD_ID=xxxxxxx

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ client.once('ready', async () => {
   console.log('Bot session started:', new Date());
 
   // Fetch Guild members on startup to ensure the integrity of the cache
-  const guild = await client.guilds.fetch('505093832157691914');
+  const guild = await client.guilds.fetch(process.env.DISCORD_GUILD_ID);
   await guild.members.fetch();
 });
 


### PR DESCRIPTION
This commit:
- Refactors the usage of the Discord Guild ID to use an environment variable.
- Updates the `.env.sample` such that there's visibility on the requirement of this key.