### PR TITLE
Fix text structure for DATA command

### DIFF
--- a/botCommands/simpleCommands.js
+++ b/botCommands/simpleCommands.js
@@ -56,7 +56,7 @@ Instead of asking if anyone can help you, ask your question outright so people c
 "Hey, does anyone know how to set CSS styles with Javascript?"
 
 **Good**:
-"Hey, I'm having trouble setting CSS styles via Javascript."
+"Hey, I'm having trouble setting CSS styles via Javascript.
 
 Here's my code:
 \`\`\`Code snippet\`\`\`\

--- a/botCommands/simpleCommands.js
+++ b/botCommands/simpleCommands.js
@@ -52,16 +52,17 @@ const data = {
       .setDescription(`
 Instead of asking if anyone can help you, ask your question outright so people can help you!
 
-**Bad**: "Hey, does anyone know how to set CSS styles with Javascript?"
+**Bad**:
+"Hey, does anyone know how to set CSS styles with Javascript?"
 
 **Good**:
-"Hey, I'm having trouble setting CSS styles via Javascript.
+"Hey, I'm having trouble setting CSS styles via Javascript."
 
 Here's my code:
 \`\`\`Code snippet\`\`\`\
 
 And here is the error I'm receiving:
-\`Cannot set attribute 'style' of null\` "
+\`\`\`Cannot set attribute 'style' of null\`\`\`"
 
 **https://www.dontasktoask.com/**
         `);


### PR DESCRIPTION
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`

-   [ ] I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date

<hr>

**1. Because:**
  - The text structure wasn't consistent (new line, missing quotation mark, and ``` wasn't used for the error message)
  
**2. This PR:**
Makes the text structure more consistent.


**3. Additional Information:**
I noticed that there was a comment in there saying:

```js
  // this weird formating is needed because of some indentation on mobile
```
but I didn't want to assume for which it was meant, so I roughly tested it privately on mobile, but there was no indentation issue there. Nevertheless, there might be that issue when the content is in a card on the actual outcome.  


