### PR TITLE
move getting hired message handler to allow other cmds

### DIFF
--- a/botEngine.js
+++ b/botEngine.js
@@ -73,12 +73,6 @@ async function listenToMessages(client) {
       return;
     }
 
-    if (message.channel.id === process.env.DISCORD_GETTING_HIRED_CHANNEL_ID) {
-      await gettingHiredMessageService.handleMessage(message, isAdminMessage);
-
-      return;
-    }
-
     const authorEntryCount = authorBuffer.reduce((count, current) => {
       if (current.author === message.author.id) {
         return count + 1;
@@ -121,6 +115,12 @@ async function listenToMessages(client) {
         }
       }
     });
+
+    if (message.channel.id === process.env.DISCORD_GETTING_HIRED_CHANNEL_ID) {
+      await gettingHiredMessageService.handleMessage(message, isAdminMessage);
+
+      return;
+    }
 
     if (message.channel.id === '690618925494566912') { // introductions
       if (!isAdminMessage) {


### PR DESCRIPTION
Problem:
Regular bot commands do not work in the getting hired channel

This commit:
- Moves the service message handler after the command validator.