### PR TITLE
Fix NOBOT_ROLE_ID

### DIFF
--- a/botEngine.js
+++ b/botEngine.js
@@ -152,7 +152,7 @@ async function listenToReactions(client) {
       }
     }
 
-    const NOBOT_ROLE_ID = '78376417617877403';
+    const NOBOT_ROLE_ID = '783764176178774036';
 
     // since user argument doesn't have guild roles,
     // we need to get user from guild to check their roles


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [X] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [X] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`

Complete the following checkboxes ONLY IF they are applicable to your PR. You can complete them later if they are not currently applicable:
-   [X] I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date

<hr>

**1. Because:** NOBOT_ROLE_ID is incorrectly being assigned the wrong value in one location
<!--
If this PR closes an open issue, replace the XXXXX below with the issue number, e.g. Closes #2013. Or if the issue is in another TOP repo replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

Otherwise, provide a clear and concise reason for your pull request, e.g. what problem it solves or what benefit it provides. If this PR is related to, but does not close, another issue or PR, you can also link it as above without the 'Closes' keyword, e.g. "Related to #2013".
 -->
Closes #XXXXX


**2. This PR:** assigns the correct value
<!--
A bullet point list of one or more items outlining what was done in this PR to solve the problem(s) or implement the feature/enhancement.
 -->


**3. Additional Information:**
<!-- Any additional information about the PR, such as a link to a Discord discussion, etc. -->

