### PR TITLE
Fix nobot check in message listener

### DIFF
--- a/botEngine.js
+++ b/botEngine.js
@@ -54,15 +54,10 @@ async function listenToMessages(client) {
     }
 
     const NOBOT_ROLE_ID = '783764176178774036';
+    const isMessageAuthorNobot = message.member.roles.cache.has(NOBOT_ROLE_ID);
 
     // can't bot if user is NOBOT
-    if (
-      message.author
-      && message.author.lastMessage
-      && message.author.lastMessage.member
-      && message.author.lastMessage.member.roles.cache
-      && message.author.lastMessage.member.roles.cache.has(NOBOT_ROLE_ID)
-    ) {
+    if (isMessageAuthorNobot) {
       return;
     }
 


### PR DESCRIPTION
Reason: was broken probably because of API changes from discord.js v12

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [X] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [X] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`

Complete the following checkboxes ONLY IF they are applicable to your PR. You can complete them later if they are not currently applicable:
-   [ ] I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date

<hr>

**1. Because:**
<!--
If this PR closes an open issue, replace the XXXXX below with the issue number, e.g. Closes #2013. Or if the issue is in another TOP repo replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

Otherwise, provide a clear and concise reason for your pull request, e.g. what problem it solves or what benefit it provides. If this PR is related to, but does not close, another issue or PR, you can also link it as above without the 'Closes' keyword, e.g. "Related to #2013".
 -->
Nobot broken


**2. This PR:**
<!--
A bullet point list of one or more items outlining what was done in this PR to solve the problem(s) or implement the feature/enhancement.
 -->
Hopefully fixes nobot

**3. Additional Information:**
<!-- Any additional information about the PR, such as a link to a Discord discussion, etc. -->

n/a