### PR TITLE
feat: disallow adding multiple points

### DIFF
--- a/botCommands/__snapshots__/points.test.js.snap
+++ b/botCommands/__snapshots__/points.test.js.snap
@@ -26,21 +26,21 @@ exports[`?++ callback returns correct output for more than five mentioned users 
 
 exports[`?++ callback returns correct output for more than five mentioned users 2`] = `"Thanks for the great question! <@2> now has 12 points"`;
 
-exports[`?++ callback returns correct output for more than five mentioned users 3`] = `"Thanks for the great question! <@2> now has 5 points"`;
+exports[`?++ callback returns correct output for more than five mentioned users 3`] = `"Thanks for the great question! <@3> now has 5 points"`;
 
-exports[`?++ callback returns correct output for more than five mentioned users 4`] = `"Thanks for the great question! <@2> now has 3 points"`;
+exports[`?++ callback returns correct output for more than five mentioned users 4`] = `"Thanks for the great question! <@4> now has 3 points"`;
 
-exports[`?++ callback returns correct output for more than five mentioned users 5`] = `"Thanks for the great question! <@2> now has 2 points"`;
+exports[`?++ callback returns correct output for more than five mentioned users 5`] = `"Thanks for the great question! <@5> now has 2 points"`;
 
-exports[`?++ callback returns correct output for more than five mentioned users 6`] = `"Thanks for the great question! <@2> now has 23 points"`;
+exports[`?++ callback returns correct output for more than five mentioned users 6`] = `"Thanks for the great question! <@6> now has 23 points"`;
 
 exports[`?++ callback returns correct output for up to five mentioned users 1`] = `"Thanks for the great question! <@2> now has 35 points"`;
 
-exports[`?++ callback returns correct output for up to five mentioned users 2`] = `"Thanks for the great question! <@2> now has 23 points"`;
+exports[`?++ callback returns correct output for up to five mentioned users 2`] = `"Thanks for the great question! <@3> now has 23 points"`;
 
-exports[`?++ callback returns correct output for up to five mentioned users 3`] = `"Thanks for the great question! <@2> now has 4 points"`;
+exports[`?++ callback returns correct output for up to five mentioned users 3`] = `"Thanks for the great question! <@4> now has 4 points"`;
 
-exports[`?++ callback returns correct output for up to five mentioned users 4`] = `"Thanks for the great question! <@2> now has 2 points"`;
+exports[`?++ callback returns correct output for up to five mentioned users 4`] = `"Thanks for the great question! <@5> now has 2 points"`;
 
 exports[`@user -- callback returns correct output 1`] = `"http://media.riffsy.com/images/636a97aa416ad674eb2b72d4a6e9ad6c/tenor.gif"`;
 
@@ -66,20 +66,42 @@ exports[`callback returns correct output for a user mentioning themselves 2`] = 
 
 exports[`callback returns correct output for more than five mentioned users 1`] = `"you can only do 5 at a time..... "`;
 
-exports[`callback returns correct output for more than five mentioned users 2`] = `"Sweet! <@2> now has 11 points"`;
+exports[`callback returns correct output for more than five mentioned users 2`] = `"Sweet! <@2> now has 24 points"`;
 
-exports[`callback returns correct output for more than five mentioned users 3`] = `"Nice! <@2> now has 4 points"`;
+exports[`callback returns correct output for more than five mentioned users 3`] = `"Sweet! <@3> now has 11 points"`;
 
-exports[`callback returns correct output for more than five mentioned users 4`] = `"Nice! <@2> now has 2 points"`;
+exports[`callback returns correct output for more than five mentioned users 4`] = `"Nice! <@4> now has 4 points"`;
 
-exports[`callback returns correct output for more than five mentioned users 5`] = `"Nice! <@2> now has 1 point"`;
+exports[`callback returns correct output for more than five mentioned users 5`] = `"Nice! <@5> now has 2 points"`;
 
-exports[`callback returns correct output for more than five mentioned users 6`] = `"Sweet! <@2> now has 22 points"`;
+exports[`callback returns correct output for more than five mentioned users 6`] = `"Nice! <@6> now has 1 point"`;
 
 exports[`callback returns correct output for up to five mentioned users 1`] = `"Woot! <@2> now has 34 points"`;
 
-exports[`callback returns correct output for up to five mentioned users 2`] = `"Sweet! <@2> now has 22 points"`;
+exports[`callback returns correct output for up to five mentioned users 2`] = `"Sweet! <@3> now has 22 points"`;
 
-exports[`callback returns correct output for up to five mentioned users 3`] = `"Nice! <@2> now has 3 points"`;
+exports[`callback returns correct output for up to five mentioned users 3`] = `"Nice! <@4> now has 3 points"`;
 
-exports[`callback returns correct output for up to five mentioned users 4`] = `"Nice! <@2> now has 1 point"`;
+exports[`callback returns correct output for up to five mentioned users 4`] = `"Nice! <@5> now has 1 point"`;
+
+exports[`callback where one user is mentioned more than once returns correct output for 1 user mentioned more than once with another user 1`] = `"Only maintainers or core members can give double points!"`;
+
+exports[`callback where one user is mentioned more than once returns correct output for 1 user mentioned more than once with another user 2`] = `"awwwww shucks... :heart_eyes:"`;
+
+exports[`callback where one user is mentioned more than once returns correct output for 1 user mentioned more than once with another user 3`] = `"Sweet! <@2> now has 22 points"`;
+
+exports[`callback where one user is mentioned more than once returns correct output for only 1 user mentioned more than 5 times 1`] = `"Only maintainers or core members can give double points!"`;
+
+exports[`callback where one user is mentioned more than once returns correct output for only 1 user mentioned more than 5 times 2`] = `"Only maintainers or core members can give double points!"`;
+
+exports[`callback where one user is mentioned more than once returns correct output for only 1 user mentioned more than 5 times 3`] = `"Only maintainers or core members can give double points!"`;
+
+exports[`callback where one user is mentioned more than once returns correct output for only 1 user mentioned more than 5 times 4`] = `"Only maintainers or core members can give double points!"`;
+
+exports[`callback where one user is mentioned more than once returns correct output for only 1 user mentioned more than 5 times 5`] = `"Only maintainers or core members can give double points!"`;
+
+exports[`callback where one user is mentioned more than once returns correct output for only 1 user mentioned more than 5 times 6`] = `"Sweet! <@2> now has 6 points"`;
+
+exports[`callback where one user is mentioned more than once returns correct output for only 1 user mentioned twice 1`] = `"Only maintainers or core members can give double points!"`;
+
+exports[`callback where one user is mentioned more than once returns correct output for only 1 user mentioned twice 2`] = `"Sweet! <@2> now has 6 points"`;

--- a/botCommands/points.js
+++ b/botCommands/points.js
@@ -14,9 +14,11 @@ function gifPicker(gifContainer, clubChannel) {
 
 function getUserIdsFromMessage(client, author, guild, text, regex, authorMember, channel) {
   const matches = [];
+  const processedIDs = [];
   let match = regex.exec(text);
 
   while (match !== null) {
+    const userID = match[1].replace('!', '');
     if (match[2] === '?++') {
       let isAdmin = false;
       authorMember.roles.cache.forEach((value) => {
@@ -26,13 +28,18 @@ function getUserIdsFromMessage(client, author, guild, text, regex, authorMember,
       });
 
       if (isAdmin) {
-        matches.push([match[1].replace('!', ''), 2]);
+        matches.push([userID, 2]);
       } else {
         channel.send('Only maintainers or core members can give double points!');
       }
       match = regex.exec(text);
     } else {
-      matches.push([match[1].replace('!', ''), 1]);
+      if (processedIDs.includes(userID)) {
+        channel.send('Only maintainers or core members can give double points!');
+      } else {
+        processedIDs.push(userID);
+        matches.push([userID, 1]);
+      }
       match = regex.exec(text);
     }
   }

--- a/botCommands/points.test.js
+++ b/botCommands/points.test.js
@@ -275,9 +275,9 @@ describe('callback', () => {
 
   it('returns correct output for up to five mentioned users', async () => {
     const mentionedUser1 = User([], 2, 33);
-    const mentionedUser2 = User([], 2, 21);
-    const mentionedUser3 = User([], 2, 2);
-    const mentionedUser4 = User([], 2, 0);
+    const mentionedUser2 = User([], 3, 21);
+    const mentionedUser3 = User([], 4, 2);
+    const mentionedUser4 = User([], 5, 0);
     const client = Client(
       [
         author,
@@ -338,12 +338,133 @@ describe('callback', () => {
     expect(data.channel.send.mock.calls[3][0]).toMatchSnapshot();
   });
 
+  describe('where one user is mentioned more than once', () => {
+    it('returns correct output for only 1 user mentioned twice', async () => {
+      const mentionedUser1 = User([], 2, 5);
+      const client = Client(
+        [
+          author,
+          mentionedUser1,
+        ],
+        channel,
+      );
+      const data = {
+        author,
+        content: `${mentionedUser1.id} ++ ${mentionedUser1.id} ++`,
+        channel,
+        client,
+        guild: Guild([
+          author,
+          mentionedUser1,
+        ]),
+      };
+
+      axios.post
+        .mockResolvedValueOnce({
+          data: {
+            ...mentionedUser1,
+            points: (mentionedUser1.points += 1),
+          },
+        });
+
+      await commands.awardPoints.cb(data);
+
+      expect(data.channel.send).toHaveBeenCalledTimes(2);
+      expect(data.channel.send.mock.calls[0][0]).toMatchSnapshot();
+      expect(data.channel.send.mock.calls[1][0]).toMatchSnapshot();
+    });
+
+    it('returns correct output for only 1 user mentioned more than 5 times', async () => {
+      const mentionedUser1 = User([], 2, 5);
+      const client = Client(
+        [
+          author,
+          mentionedUser1,
+        ],
+        channel,
+      );
+
+      const data = {
+        author,
+        content: `${mentionedUser1.id} ++ ${mentionedUser1.id} ++ ${mentionedUser1.id} ++ ${mentionedUser1.id} ++ ${mentionedUser1.id} ++ ${mentionedUser1.id} ++`,
+        channel,
+        client,
+        guild: Guild([
+          author,
+          mentionedUser1,
+        ]),
+      };
+
+      axios.post
+        .mockResolvedValueOnce({
+          data: {
+            ...mentionedUser1,
+            points: (mentionedUser1.points += 1),
+          },
+        });
+
+      await commands.awardPoints.cb(data);
+
+      expect(data.channel.send).toHaveBeenCalledTimes(6);
+      expect(data.channel.send.mock.calls[0][0]).toMatchSnapshot();
+      expect(data.channel.send.mock.calls[1][0]).toMatchSnapshot();
+      expect(data.channel.send.mock.calls[2][0]).toMatchSnapshot();
+      expect(data.channel.send.mock.calls[3][0]).toMatchSnapshot();
+      expect(data.channel.send.mock.calls[4][0]).toMatchSnapshot();
+      expect(data.channel.send.mock.calls[5][0]).toMatchSnapshot();
+    });
+
+    it('returns correct output for 1 user mentioned more than once with another user', async () => {
+      const mentionedUser1 = User([], 2, 21);
+      const mentionedUser2 = User([], 3, 23);
+      const client = Client(
+        [
+          author,
+          mentionedUser1,
+        ],
+        channel,
+      );
+
+      const data = {
+        author,
+        content: `${mentionedUser1.id} ++ ${mentionedUser1.id} ++ ${mentionedUser2.id} ++`,
+        channel,
+        client,
+        guild: Guild([
+          author,
+          mentionedUser1,
+        ]),
+      };
+
+      axios.post
+        .mockResolvedValueOnce({
+          data: {
+            ...mentionedUser1,
+            points: (mentionedUser1.points += 1),
+          },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            ...mentionedUser2,
+            points: (mentionedUser2.points += 1),
+          },
+        });
+
+      await commands.awardPoints.cb(data);
+
+      expect(data.channel.send).toHaveBeenCalledTimes(3);
+      expect(data.channel.send.mock.calls[0][0]).toMatchSnapshot();
+      expect(data.channel.send.mock.calls[1][0]).toMatchSnapshot();
+      expect(data.channel.send.mock.calls[2][0]).toMatchSnapshot();
+    });
+  });
+
   it('returns correct output for more than five mentioned users', async () => {
     const mentionedUser1 = User([], 2, 10);
-    const mentionedUser2 = User([], 2, 3);
-    const mentionedUser3 = User([], 2, 1);
-    const mentionedUser4 = User([], 2, 0);
-    const mentionedUser5 = User([], 2, 21);
+    const mentionedUser2 = User([], 3, 3);
+    const mentionedUser3 = User([], 4, 1);
+    const mentionedUser4 = User([], 5, 0);
+    const mentionedUser5 = User([], 6, 21);
     const client = Client(
       [
         author,
@@ -584,9 +705,9 @@ describe('?++ callback', () => {
 
   it('returns correct output for up to five mentioned users', async () => {
     const mentionedUser1 = User([], 2, 33);
-    const mentionedUser2 = User([], 2, 21);
-    const mentionedUser3 = User([], 2, 2);
-    const mentionedUser4 = User([], 2, 0);
+    const mentionedUser2 = User([], 3, 21);
+    const mentionedUser3 = User([], 4, 2);
+    const mentionedUser4 = User([], 5, 0);
     const memberMap = new Map();
     memberMap.set('role-1', { name: 'core' });
     const member = Member(memberMap);
@@ -652,10 +773,10 @@ describe('?++ callback', () => {
 
   it('returns correct output for more than five mentioned users', async () => {
     const mentionedUser1 = User([], 2, 10);
-    const mentionedUser2 = User([], 2, 3);
-    const mentionedUser3 = User([], 2, 1);
-    const mentionedUser4 = User([], 2, 0);
-    const mentionedUser5 = User([], 2, 21);
+    const mentionedUser2 = User([], 3, 3);
+    const mentionedUser3 = User([], 4, 1);
+    const mentionedUser4 = User([], 5, 0);
+    const mentionedUser5 = User([], 6, 21);
     const memberMap = new Map();
     memberMap.set('role-1', { name: 'core' });
     const member = Member(memberMap);


### PR DESCRIPTION
## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Normal users seemed to be able to grant a user more than one point by referencing them more than once in a message.


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
* Adds a check in `getUserIdsFromMessage` to prevent duplicates
* Adds tests for the scenario where a user is mentioned twice in a message.
* Update other tests to use unique user IDs
* Update snapshots to accommodate test changes

## Issue
Closes #257 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR adds new features or functionality, I have added new tests
-   [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
