### PR TITLE
Points.js: Add two more possible exclamations for certain milestones

### DIFF
--- a/botCommands/points.js
+++ b/botCommands/points.js
@@ -97,6 +97,12 @@ function exclamation(points, isGoodQuestion) {
   if (points > 299 && points < 306) {
     return 'OK YOU CAN STOP NOW:';
   }
+  if(points === 1000) {
+    return 'ONE THOUSAND POINTS';
+  }
+  if(points === 4000) {
+    return '\`//TODO: Implement Club 4000\`'
+  }
   return 'Woot!';
 }
 

--- a/botCommands/points.js
+++ b/botCommands/points.js
@@ -97,11 +97,11 @@ function exclamation(points, isGoodQuestion) {
   if (points > 299 && points < 306) {
     return 'OK YOU CAN STOP NOW:';
   }
-  if(points === 1000) {
+  if (points === 1000) {
     return 'ONE THOUSAND POINTS';
   }
-  if(points === 4000) {
-    return '\`//TODO: Implement Club 4000\`'
+  if (points === 4000) {
+    return '`//TODO: Implement Club 4000`';
   }
   return 'Woot!';
 }


### PR DESCRIPTION


## Because
- It is nice to mark certain significant milestones (1K and 4K) in gained points


## This PR
- Adds two new possible exclamations, one for 1000 points and one for 4000 points


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR adds new features or functionality, I have added new tests
-   [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
