### PR TITLE
New era commands: add code slash command

### DIFF
--- a/new-era-commands/slash/code.js
+++ b/new-era-commands/slash/code.js
@@ -1,0 +1,52 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('code')
+    .setDescription('Help with embedding code')
+    .addUserOption((option) => option.setName('user').setDescription('user to ping')),
+  execute: async (interaction) => {
+    const userId = interaction.options.getUser('user')?.id;
+    const codeEmbed = new EmbedBuilder()
+      .setColor('#0099ff')
+      .setTitle('HOW TO EMBED CODE SNIPPETS')
+      .setDescription(
+        !userId
+          ? "Hey, here's some helpful tips on sharing your code with others!"
+          : `Hey, <@${userId}>, here's some helpful tips on sharing your code with others!`,
+      )
+      // weird formating is needer to avoid identation on mobile
+      .addFields([
+        {
+          name: 'Sharing Code on Discord',
+          value: `To write multiple lines of code with language syntax highlighting, use three backticks (<https://i.stack.imgur.com/ETTnT.jpg>), followed by the language.
+  
+  \\\`\\\`\\\`js
+  [Put your JavaScript Code here!]
+  \\\`\\\`\\\`
+  
+  For \`inline code\` use one backtick (no syntax highlighting):
+  
+  \\\`Code here!\\\`
+        `,
+        },
+        {
+          name: 'Link a Code Sandbox to share Webpack/React examples',
+          value: 'https://codesandbox.io/',
+          inline: true,
+        },
+        {
+          name: 'Link a Repl.it to share Javascript/Ruby examples',
+          value: 'https://replit.com/',
+          inline: true,
+        },
+
+        {
+          name: 'Link a Codepen to share basic HTML/CSS/Javascript examples',
+          value: 'https://codepen.io/',
+          inline: true,
+        },
+      ]);
+    await interaction.reply({ embeds: [codeEmbed] });
+  },
+};


### PR DESCRIPTION
## Because
- We are ever moving onwards towards slash commands


## This PR
- adds a slashcommand version of `!code`


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR adds new features or functionality, I have added new tests
