### PR TITLE
/data: update wording to be more reflective of actual questions asked, and in line with /question command

### DIFF
--- a/new-era-commands/slash/data.js
+++ b/new-era-commands/slash/data.js
@@ -10,18 +10,19 @@ module.exports = {
       .setColor('#cc9543')
       .setURL('https://www.dontasktoask.com/')
       .setDescription(`
-Instead of asking if anyone can help you, ask your question outright so people can help you!
+Instead of asking if anyone can help you, ask your question outright with as much information as possible so people will know if they can help you.
 
-**Bad**: "Hey, does anyone know how to set CSS styles with Javascript?"
+**Bad**: "Hey, anyone around that is really good with CSS?"
 
 **Good**:
-"Hey, I'm having trouble setting CSS styles via Javascript.
+"Hey, I'm having trouble setting CSS styles via Javascript."
 
-Here's my code:
-\`\`\`Code snippet\`\`\`\
-
-And here is the error I'm receiving:
-\`Cannot set attribute 'style' of null\` "
+Project/Exercise: 
+Lesson link:
+Code: [code sandbox like replit or codepen]
+Issue/Problem: [screenshots if applicable]
+What I expected:
+What I've tried:
 
 **https://www.dontasktoask.com/**
         `);


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
The majority of the questions we see that get responded to with the `/data` command are questions that don't give away any information. The current `BAD` example contains more information than is usually given when responded to with `/data`. The current `BAD` example could also be followed up with the `/question` command since we already at least now roughly know what the issue is. I also think it would be better to make it more in line with the `/question` command because the current data output mentions nothing about 'what you've tried' for example. 

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- edit the first sentence to also emphasise that enough information has to be included in a question
- update the **BAD** question example
- add the same template as used in the `/question` command so these two command are more in line

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #283 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If this PR adds new features or functionality, I have added new tests
-   [ ] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
