### PR TITLE
chooseyourpath: fix custom emoij handling

### DIFF
--- a/new-era-commands/slash/chooseyourpath.js
+++ b/new-era-commands/slash/chooseyourpath.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 
-const PATHS = [{ name: 'Full Stack JavaScript', emoji: ':node:' }, { name: 'Ruby on Rails', emoji: ':ruby:' }];
+const PATHS = [{ name: 'Full Stack JavaScript', emoji: '<:node:936642975268749313>' }, { name: 'Ruby on Rails', emoji: '<:ruby:517023177386491911>' }];
 
 const QUOTES = [
   (path) => `Thou shalt follow the ${path.name} path. May the force be with thee. :crossed_swords:`,


### PR DESCRIPTION
## Because
- While default emoij's can be embedded by simply using `:name:` in a string, this does not work for server specific emoij's, which instead require the `<:name:id>` format. Currently the ruby and node emoij's are using the standard way instead of the server specific way, causing `:node:` and `:ruby:` to show up instead of the intended emoij's


## This PR
- Changes the way the path emoijs are specified to the right formatting, which causes them to actually display the intended emoij


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR