### PR TITLE
bot help command: update community guide links for the help command

### DIFF
--- a/botCommands/__snapshots__/help.test.js.snap
+++ b/botCommands/__snapshots__/help.test.js.snap
@@ -173,7 +173,7 @@ exports[`!help snapshot should return the correct output 1`] = `
   "embeds": [
     {
       "color": 13407555,
-      "description": "**By posting in this chatroom you agree to our [rules](https://www.theodinproject.com/community_rules) and our [community expectations](https://www.theodinproject.com/community_expectations)**.",
+      "description": "**By posting in this chatroom you agree to our [rules](https://www.theodinproject.com/guides/community/rules)** and our **[community expectations](https://www.theodinproject.com/guides/community/expectations)**.",
       "fields": [
         {
           "inline": true,

--- a/botCommands/help.js
+++ b/botCommands/help.js
@@ -7,7 +7,7 @@ const help = {
     const helpEmbed = new Discord.EmbedBuilder()
       .setColor('#cc9543')
       .setTitle('Help')
-      .setDescription('**By posting in this chatroom you agree to our [rules](https://www.theodinproject.com/community_rules) and our [community expectations](https://www.theodinproject.com/community_expectations)**.')
+      .setDescription('**By posting in this chatroom you agree to our [rules](https://www.theodinproject.com/guides/community/rules)** and our **[community expectations](https://www.theodinproject.com/guides/community/expectations)**.')
       .addFields([
         {
           name: 'Add Points',

--- a/new-era-commands/slash/help.js
+++ b/new-era-commands/slash/help.js
@@ -8,7 +8,7 @@ module.exports = {
     const helpEmbed = new EmbedBuilder()
       .setColor('#cc9543')
       .setTitle('Help')
-      .setDescription('**By posting in this chatroom you agree to our [rules](https://www.theodinproject.com/community_rules)** and our **[community expectations](https://www.theodinproject.com/community_expectations)**.')
+      .setDescription('**By posting in this chatroom you agree to our [rules](https://www.theodinproject.com/guides/community/rules)** and our **[community expectations](https://www.theodinproject.com/guides/community/expectations)**.')
       .addFields([
         {
           name: 'Add Points',


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
The links in the commands are outdated and lead to a 404 page

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- update the links

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If this PR adds new features or functionality, I have added new tests
-   [ ] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
