### PR TITLE
Bootcamps: make !bootcamp also work

### DIFF
--- a/botCommands/bootcamps.js
+++ b/botCommands/bootcamps.js
@@ -1,7 +1,7 @@
 const { registerBotCommand } = require('../botEngine');
 
 const command = {
-  regex: /(?<!\S)!bootcamps(?!\S)/,
+  regex: /(?<!\S)!bootcamps?(?!\S)/,
   cb: () => 'Friends don\'t let friends commit to bootcamps without being informed.  https://twitter.com/lzsthw/status/1212284566431576069',
 };
 

--- a/botCommands/bootcamps.test.js
+++ b/botCommands/bootcamps.test.js
@@ -7,6 +7,10 @@ describe('!bootcamps', () => {
       [' !bootcamps'],
       ['!bootcamps @odin-bot'],
       ['@odin-bot !bootcamps'],
+      ['!bootcamp'],
+      [' !bootcamp'],
+      ['!bootcamp @odin-bot'],
+      ['@odin-bot !bootcamp'],
     ])('correct strings trigger the callback', (string) => {
       expect(command.regex.test(string)).toBeTruthy();
     });
@@ -14,8 +18,6 @@ describe('!bootcamps', () => {
     it.each([
       ['botcamps'],
       ['bootcamps'],
-      ['bootcamp'],
-      ['!bootcamp'],
       ['!bootcmp'],
       ['! bootcamps'],
       ['!abootcamps'],


### PR DESCRIPTION
## Because
- `!bootcamp` is a reasonable alternative to `!bootcamps`, and often gets used when people want `!bootcamp`


## This PR
- Modifies the regex to make `!bootcamp` work, and update associated jest tests


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR adds new features or functionality, I have added new tests
-   [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
