### PR TITLE
Bootcamps: change link to Web Archive

### DIFF
--- a/botCommands/__snapshots__/bootcamps.test.js.snap
+++ b/botCommands/__snapshots__/bootcamps.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`!bootcamps callback returns correct output 1`] = `"Friends don't let friends commit to bootcamps without being informed.  https://twitter.com/lzsthw/status/1212284566431576069"`;
+exports[`!bootcamps callback returns correct output 1`] = `"Friends don't let friends commit to bootcamps without being informed.  https://web.archive.org/web/20220410160426/https://twitter.com/lzsthw/status/1212284566431576069"`;

--- a/botCommands/bootcamps.js
+++ b/botCommands/bootcamps.js
@@ -2,7 +2,7 @@ const { registerBotCommand } = require('../botEngine');
 
 const command = {
   regex: /(?<!\S)!bootcamps?(?!\S)/,
-  cb: () => 'Friends don\'t let friends commit to bootcamps without being informed.  https://twitter.com/lzsthw/status/1212284566431576069',
+  cb: () => 'Friends don\'t let friends commit to bootcamps without being informed.  https://web.archive.org/web/20220410160426/https://twitter.com/lzsthw/status/1212284566431576069',
 };
 
 registerBotCommand(command.regex, command.cb);


### PR DESCRIPTION
## Because
- Twitter is becoming increasingly hostile to non-logged in users and seems to be degrading in general, leading to issues with accessing the bootcamp tweet


## This PR
- Changes it to a Web Archive version, as linked on Discord (https://discord.com/channels/505093832157691914/707225752608964628/1125631263953387540)


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
