### PR TITLE
!windows: Move WSL to the supported category

### DIFF
--- a/botCommands/__snapshots__/windows.test.js.snap
+++ b/botCommands/__snapshots__/windows.test.js.snap
@@ -5,7 +5,7 @@ exports[`!windows callback returns correct output 1`] = `
   "embeds": [
     {
       "color": 13407555,
-      "description": "**The Odin Project does not support Windows, WSL, or any OS outside of our recommendations**. We are happy to assist with any questions about installing a VM or dual booting Linux. <https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/installation-overview#os-options>",
+      "description": "**The Odin Project does not support Windows, or any OS outside of our recommendations**. We are happy to assist with any questions about installing a VM, using WSL, or dual booting Linux. <https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/installation-overview#os-options>",
       "title": "Windows",
       "url": "https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/installation-overview#os-options",
     },

--- a/botCommands/windows.js
+++ b/botCommands/windows.js
@@ -7,7 +7,7 @@ const command = {
     const windowsEmbed = new Discord.EmbedBuilder()
       .setColor('#cc9543')
       .setTitle('Windows')
-      .setDescription('**The Odin Project does not support Windows, WSL, or any OS outside of our recommendations**. We are happy to assist with any questions about installing a VM or dual booting Linux. <https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/installation-overview#os-options>')
+      .setDescription('**The Odin Project does not support Windows, or any OS outside of our recommendations**. We are happy to assist with any questions about installing a VM, using WSL, or dual booting Linux. <https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/installation-overview#os-options>')
       .setURL('https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/installation-overview#os-options');
 
     return { embeds: [windowsEmbed] };

--- a/new-era-commands/slash/windows.js
+++ b/new-era-commands/slash/windows.js
@@ -8,7 +8,7 @@ module.exports = {
     const windowsEmbed = new EmbedBuilder()
       .setColor('#cc9543')
       .setTitle('Windows')
-      .setDescription('**The Odin Project does not support Windows, WSL, or any OS outside of our recommendations**. We are happy to assist with any questions about installing a VM or dual booting Linux. <https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/installation-overview#os-options>')
+      .setDescription('**The Odin Project does not support Windows, or any OS outside of our recommendations**. We are happy to assist with any questions about installing a VM, using WSL, or dual booting Linux. <https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/installation-overview#os-options>')
       .setURL('https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/installation-overview#os-options');
 
     await interaction.reply({ embeds: [windowsEmbed] });


### PR DESCRIPTION
**DO NOT MERGE:** Depends on TheOdinProject/curriculum/pull/25402

## Because
- We're moving to support WSL2

## This PR
- Updates the `!windows` command to refer to WSL as a supported OS

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
