### PR TITLE
move legacy !question command to its own module

### DIFF
--- a/botCommands/__snapshots__/question-legacy.test.js.snap
+++ b/botCommands/__snapshots__/question-legacy.test.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`!question callback returns correct output 1`] = `
+{
+  "embeds": [
+    {
+      "color": 13407555,
+      "description": "
+Asking context-rich questions makes it easy to receive help, and makes it easy for others to help you quickly! Great engineers ask great questions, and the prompt below is an invitation to improve your skills and set yourself up for success in the workplace. 
+
+**Project/Exercise:**
+**Lesson link:**
+**Code:** [code sandbox like replit or codepen]
+**Issue/Problem:** [screenshots if applicable]
+**What I expected:** 
+**What I've tried:** 
+
+For even more context around on how to hone your question-asking skills, give this a read: https://www.theodinproject.com/guides/community/how_to_ask
+              ",
+      "title": "Asking Great Questions",
+    },
+  ],
+}
+`;

--- a/botCommands/__snapshots__/simpleCommands.test.js.snap
+++ b/botCommands/__snapshots__/simpleCommands.test.js.snap
@@ -43,29 +43,6 @@ exports[`!lenny callback returns correct output 1`] = `"( ͡° ͜ʖ ͡°)"`;
 
 exports[`!motivate callback returns correct output 1`] = `"Don't give up! https://www.youtube.com/watch?v=KxGRhd_iWuE"`;
 
-exports[`!question callback returns correct output 1`] = `
-{
-  "embeds": [
-    {
-      "color": 13407555,
-      "description": "
-Asking context-rich questions makes it easy to receive help, and makes it easy for others to help you quickly! Great engineers ask great questions, and the prompt below is an invitation to improve your skills and set yourself up for success in the workplace. 
-
-**Project/Exercise:**
-**Lesson link:**
-**Code:** [code sandbox like replit or codepen]
-**Issue/Problem:** [screenshots if applicable]
-**What I expected:** 
-**What I've tried:** 
-
-For even more context around on how to hone your question-asking skills, give this a read: https://www.theodinproject.com/guides/community/how_to_ask
-              ",
-      "title": "Asking Great Questions",
-    },
-  ],
-}
-`;
-
 exports[`!smart callback returns correct output 1`] = `"f(ಠ‿↼)z"`;
 
 exports[`!xy callback returns correct output 1`] = `"What problem are you *really* trying to solve? Check out this article to help others better understand your question: <https://xyproblem.info/>"`;

--- a/botCommands/question-legacy.js
+++ b/botCommands/question-legacy.js
@@ -1,0 +1,28 @@
+const Discord = require('discord.js');
+const { registerBotCommand } = require('../botEngine');
+
+const question = {
+  regex: /(?<!\S)!question(?!\S)/,
+  cb: () => {
+    const questionEmbed = new Discord.EmbedBuilder()
+      .setColor('#cc9543')
+      .setTitle('Asking Great Questions')
+      .setDescription(`
+Asking context-rich questions makes it easy to receive help, and makes it easy for others to help you quickly! Great engineers ask great questions, and the prompt below is an invitation to improve your skills and set yourself up for success in the workplace. 
+
+**Project/Exercise:**
+**Lesson link:**
+**Code:** [code sandbox like replit or codepen]
+**Issue/Problem:** [screenshots if applicable]
+**What I expected:** 
+**What I've tried:** 
+
+For even more context around on how to hone your question-asking skills, give this a read: https://www.theodinproject.com/guides/community/how_to_ask
+              `);
+
+    return { embeds: [questionEmbed] };
+  },
+};
+registerBotCommand(question.regex, question.cb);
+
+module.exports = question;

--- a/botCommands/question-legacy.test.js
+++ b/botCommands/question-legacy.test.js
@@ -1,0 +1,63 @@
+const question = require('./question-legacy');
+
+describe('!question', () => {
+  describe('regex', () => {
+    it.each([
+      ['!question'],
+      [' !question'],
+      ['!question @odin-bot'],
+      ['@odin-bot !question'],
+    ])('correct strings trigger the callback', (string) => {
+      expect(question.regex.test(string)).toBeTruthy();
+    });
+
+    it.each([
+      ['!quest'],
+      ['question'],
+      ['!questio'],
+      ['!questions'],
+      ['```function("!question", () => {}```'],
+      ['!questiona'],
+      [''],
+      [' '],
+      [' !'],
+      ['@odin-bot ! question'],
+      ['!ques&tion'],
+      ['!quest^ion'],
+      ['!question!'],
+      ['@odin-bot! question'],
+      ['https:!!question.com'],
+    ])("'%s' does not trigger the callback", (string) => {
+      expect(question.regex.test(string)).toBeFalsy();
+    });
+
+    it.each([
+      ['Check this out! !question'],
+      ["Don't worry about !question"],
+      ['Hey @odin-bot, !question'],
+      ['!@odin-bot ^ !me !question !tests$*'],
+    ])("'%s' - command can be anywhere in the string", (string) => {
+      expect(question.regex.test(string)).toBeTruthy();
+    });
+
+    it.each([
+      ['@user!question'],
+      ["it's about!question"],
+      ['!questionisanillusion'],
+      ['!question!'],
+      ['!question*'],
+      ['!question...'],
+    ])(
+      "'%s' - command should be its own word!group - no leading or trailing characters",
+      (string) => {
+        expect(question.regex.test(string)).toBeFalsy();
+      },
+    );
+  });
+
+  describe('callback', () => {
+    it('returns correct output', () => {
+      expect(question.cb()).toMatchSnapshot();
+    });
+  });
+});

--- a/botCommands/simpleCommands.js
+++ b/botCommands/simpleCommands.js
@@ -28,30 +28,6 @@ const fu = {
 };
 registerBotCommand(fu.regex, fu.cb);
 
-const question = {
-  regex: /(?<!\S)!question(?!\S)/,
-  cb: () => {
-    const questionEmbed = new Discord.EmbedBuilder()
-      .setColor('#cc9543')
-      .setTitle('Asking Great Questions')
-      .setDescription(`
-Asking context-rich questions makes it easy to receive help, and makes it easy for others to help you quickly! Great engineers ask great questions, and the prompt below is an invitation to improve your skills and set yourself up for success in the workplace. 
-
-**Project/Exercise:**
-**Lesson link:**
-**Code:** [code sandbox like replit or codepen]
-**Issue/Problem:** [screenshots if applicable]
-**What I expected:** 
-**What I've tried:** 
-
-For even more context around on how to hone your question-asking skills, give this a read: https://www.theodinproject.com/guides/community/how_to_ask
-              `);
-
-    return { embeds: [questionEmbed] };
-  },
-};
-registerBotCommand(question.regex, question.cb);
-
 const data = {
   regex: /(?<!\S)!data(?!\S)/,
   cb: () => {
@@ -126,7 +102,6 @@ module.exports = {
   smart,
   lenny,
   fu,
-  question,
   data,
   google,
   dab,

--- a/botCommands/simpleCommands.test.js
+++ b/botCommands/simpleCommands.test.js
@@ -247,68 +247,6 @@ describe('!fu', () => {
   });
 });
 
-describe('!question', () => {
-  describe('regex', () => {
-    it.each([
-      ['!question'],
-      [' !question'],
-      ['!question @odin-bot'],
-      ['@odin-bot !question'],
-    ])('correct strings trigger the callback', (string) => {
-      expect(commands.question.regex.test(string)).toBeTruthy();
-    });
-
-    it.each([
-      ['!quest'],
-      ['question'],
-      ['!questio'],
-      ['!questions'],
-      ['```function("!question", () => {}```'],
-      ['!questiona'],
-      [''],
-      [' '],
-      [' !'],
-      ['@odin-bot ! question'],
-      ['!ques&tion'],
-      ['!quest^ion'],
-      ['!question!'],
-      ['@odin-bot! question'],
-      ['https:!!question.com'],
-    ])("'%s' does not trigger the callback", (string) => {
-      expect(commands.question.regex.test(string)).toBeFalsy();
-    });
-
-    it.each([
-      ['Check this out! !question'],
-      ["Don't worry about !question"],
-      ['Hey @odin-bot, !question'],
-      ['!@odin-bot ^ !me !question !tests$*'],
-    ])("'%s' - command can be anywhere in the string", (string) => {
-      expect(commands.question.regex.test(string)).toBeTruthy();
-    });
-
-    it.each([
-      ['@user!question'],
-      ["it's about!question"],
-      ['!questionisanillusion'],
-      ['!question!'],
-      ['!question*'],
-      ['!question...'],
-    ])(
-      "'%s' - command should be its own word!group - no leading or trailing characters",
-      (string) => {
-        expect(commands.question.regex.test(string)).toBeFalsy();
-      },
-    );
-  });
-
-  describe('callback', () => {
-    it('returns correct output', () => {
-      expect(commands.question.cb()).toMatchSnapshot();
-    });
-  });
-});
-
 describe('!data', () => {
   describe('regex', () => {
     it.each([['!data'], [' !data'], ['!data @odin-bot'], ['@odin-bot !data']])(


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
We are slowly but surely updating our commands to slash commands and I'm doing some bot housekeeping. The `!question` command was decided on in the past as a great one to keep in the legacy format as well. It works nicely when typed in a sentence like:
> Hi there! I really think people would be way better equipped to help you out if you format your `!question` according to the below bot output. 


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- moves the `!question` command out of the `simpleCommands` file into their own `question-legacy` file
- adds a separate test file for the `!question` command and removes the test from the `simpleCommands.test.js`
- adds a separate snapshot file for the `!question` cb and removes it from the `simpleCommands` snapshot file.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)

-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR adds new features or functionality, I have added new tests
-   [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
