### PR TITLE
/searchtop: suppres google embed

### DIFF
--- a/new-era-commands/slash/searchtop.js
+++ b/new-era-commands/slash/searchtop.js
@@ -12,7 +12,7 @@ module.exports = {
     const searchUrl = `https://www.google.com/search?q=site:theodinproject.com+${prompt.replaceAll(' ', '+')}`;
 
     await interaction.reply(
-      userId ? `<@${userId}>\nSearching The Odin Project for \`${prompt}\`: ${searchUrl}` : `Searching The Odin Project for \`${prompt}\`: ${searchUrl}`,
+      userId ? `<@${userId}>\nSearching The Odin Project for \`${prompt}\`: <${searchUrl}>` : `Searching The Odin Project for \`${prompt}\`: <${searchUrl}>`,
     );
   },
 };


### PR DESCRIPTION
## Because
- Google has added an embed to the search links, which adds nothing but takes up a large amount of chat space


## This PR
- suppresses the embed from the link


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
