### PR TITLE
README.md: add TOP abbreviation & Wiki page list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin Bot - Discord Bot for The Odin Project
 
-Welcome to the Odin Bot repository! This is the codebase that powers Odin's right-hand bot, which is used by the tens of thousands of dedicated Odinites in the [Discord community of The Odin Project](https://discord.gg/fbFCkYabZB). 
+Welcome to the Odin Bot repository! This is the codebase that powers Odin's right-hand bot, which is used by the tens of thousands of dedicated Odinites in the [Discord community of The Odin Project](https://discord.gg/fbFCkYabZB) (TOP). 
 
 [The Odin Project](https://www.theodinproject.com) is an open-source curriculum for learning full-stack web development. This bot plays a crucial role in our Discord server by displaying helpful information, driving positive engagement through the points system, and incorporating various other nifty features.
 
@@ -10,11 +10,17 @@ Welcome to the Odin Bot repository! This is the codebase that powers Odin's righ
 
 This bot has been built with NodeJS and [the DiscordJS module](https://discord.js.org/#/docs/main/stable/general/welcome).
 
-
 ## Contributing
 
 We're thrilled that you're interested in contributing to the Odin Bot! Our bot depends on open source contributions to grow, improve, and thrive. Whether you're a seasoned pro or just starting out, we welcome all kinds of contributions!
 
-For more information on how to get started, we have a really helpful [wiki guide for setting up the Odin Bot](https://github.com/TheOdinProject/odin-bot-v2/wiki/Getting-Started) and please also refer to [our TOP contributing guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md).
+For more information on how to get started, please refer to [our TOP contributing guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md) and the helpful wiki pages listed below.
+
+### Odin Bot Wiki
+- **[Odin Bot Contributing Guide:](https://github.com/TheOdinProject/odin-bot-v2/wiki/Contributing-Guide)** A detailed guide on how to contribute to The Odin Project's Discord bot development.
+- **[Getting Started:](https://github.com/TheOdinProject/odin-bot-v2/wiki/Getting-Started)** Instructions on setting up Odin Bot locally on your own server
+- **[Odin Bot Commands:](https://github.com/TheOdinProject/odin-bot-v2/wiki/Commands)** Learn how to register a new command and how the callback function for a command works
+- **[Odin Bot Testing:](https://github.com/TheOdinProject/odin-bot-v2/wiki/Testing)** Learn how to setup or update test files for commands
+- **[FAQ:](https://github.com/TheOdinProject/odin-bot-v2/wiki#faq)** Frequently asked questions about development and testing
 
 Let's have a blast building and improving the Odin Bot together! We can't wait to see your awesome contributions!


### PR DESCRIPTION
## Because
**TOP abbreviation reasoning:**
Adding the TOP abbreviation in parenthesis at the top clarifies the meaning of the term when it is used later in the document. For example, this syntax is present in another TOP repo here: https://github.com/TheOdinProject/theodinproject/#readme
**Wiki page list reasoning:**
Quickly accessible project links improve developer efficiency and help new contributors locate important information.

## This PR
- "(TOP)" has been added after the link to The Odin Project's Discord server.
- In the Contributing section, a list of project wiki links has been added with a section header and the "for more information..." sentence has been slightly reworded.

## Issue
Closes #XXXXX

## Additional Information
N/A


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If this PR adds new features or functionality, I have added new tests
-   [ ] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date