### PR TITLE
new-era-commands/slash: Add memory command

### DIFF
--- a/new-era-commands/slash/memory.js
+++ b/new-era-commands/slash/memory.js
@@ -1,0 +1,21 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('memory')
+    .setDescription('A professional\'s anecdote about why you don\'t need to memorize everything you\'re learning.')
+    .addUserOption((option) => option.setName('user').setDescription('user to ping')),
+  execute: async (interaction) => {
+    const userId = interaction.options.getUser('user')?.id;
+    const memoryEmbed = new EmbedBuilder()
+      .setColor('#cc9543')
+      .setTitle('Memorization and learning to code')
+      .setDescription(
+        'Please read this [blog post about why you don\'t need to memorize everything you learn.](https://dev.to/theodinproject/memorization-and-learning-to-code-1b6h)',
+      );
+    await interaction.reply({
+      content: userId ? `<@${userId}>` : '',
+      embeds: [memoryEmbed],
+    });
+  },
+};


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
This PR adds a slash-command to the odin-bot to provide a link to Carlos' blog post on memorization, and allows users to refer question-askers seeking advice on whether to memorize the learning material.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Adds slash-command to new-era-commands directory (compare original PR linked below)
- Changes callback from prior PR to use embed format.
- Changes link to "meaningful text" to better adhere to accessibility standards.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Related to #https://github.com/TheOdinProject/odin-bot-v2/pull/403

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
Per comments on prior PR, there is currently no testing requirement for slash-commands. However, I have confirmed that the command works in a private Discord test server.

Original post with link to blog post: https://discord.com/channels/505093832157691914/564517555629457428/1146483003019767828

Recommendation to contribute a bot command as experience: https://discord.com/channels/505093832157691914/514204569572605952/1146604613315870760

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR adds new features or functionality, I have added new tests
-   [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
