### PR TITLE
Add a new club-40 gif

### DIFF
--- a/botCommands/club_40_gifs.json
+++ b/botCommands/club_40_gifs.json
@@ -63,4 +63,8 @@
     "gif": "https://i.imgur.com/DVrRqoF.gif",
     "author": "Sully"
   }
+  {
+    "gif": "https://media.tenor.com/VRYCq0ZeasQAAAAC/dundie-award.gif",
+    "author": "Unknown"
+  }
 ]


### PR DESCRIPTION
## Because
This [gif](https://media.tenor.com/VRYCq0ZeasQAAAAC/dundie-award.gif) that does not seem to have an author pop up in Club-40 and it is not in [collection of possible gifs](https://github.com/TheOdinProject/odin-bot-v2/blob/main/botCommands/club_40_gifs.json).

## This PR
- Added one club-40 .gif  

## Issue
Closes #408

## Additional Information
## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If this PR adds new features or functionality, I have added new tests
-   [ ] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
