### PR TITLE
Slash commands: Add optional user mention option

### DIFF
--- a/new-era-commands/slash/ai.js
+++ b/new-era-commands/slash/ai.js
@@ -3,8 +3,11 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('ai')
-    .setDescription('Generative AI and Learning to Code'),
+    .setDescription('Generative AI and Learning to Code')
+    .addUserOption((option) => option.setName('user').setDescription('user to ping')),
   execute: async (interaction) => {
+    const userId = interaction.options.getUser('user')?.id;
+
     const aiEmbed = new EmbedBuilder()
       .setColor('#cc9543')
       .setTitle('Generative AI and Learning Code')
@@ -26,6 +29,9 @@ module.exports = {
         ],
       );
 
-    await interaction.reply({ embeds: [aiEmbed] });
+    await interaction.reply({
+      content: userId ? `<@${userId}>` : '',
+      embeds: [aiEmbed],
+    });
   },
 };

--- a/new-era-commands/slash/bookmark.js
+++ b/new-era-commands/slash/bookmark.js
@@ -4,19 +4,25 @@ const config = require('../../config');
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('bookmark')
-    .setDescription('Info about bookmarking messages in the TOP Discord server'),
+    .setDescription('Info about bookmarking messages in the TOP Discord server')
+    .addUserOption((option) => option.setName('user').setDescription('user to ping')),
   execute: async (interaction) => {
+    const userId = interaction.options.getUser('user')?.id;
+
     const bookmarkEmbed = new EmbedBuilder()
       .setColor('#cc9543')
       .setTitle('Bookmark messages in this server')
       .setDescription(`
-To bookmark a message, react with the bookmark icon 🔖 on the message you wish to save for later. 
+To bookmark a message, react with the bookmark icon 🔖 on the message you wish to save for later.
 
-<@${config.clientId}> will then deliver the message to your DMs in an embedded format with a link to the original message in the server. 
+<@${config.clientId}> will then deliver the message to your DMs in an embedded format with a link to the original message in the server.
 
 You can delete a bookmarked message at any time from your DMs by reacting on it with the ❌ emoji.
       `);
 
-    await interaction.reply({ embeds: [bookmarkEmbed] });
+    await interaction.reply({
+      content: userId ? `<@${userId}>` : '',
+      embeds: [bookmarkEmbed],
+    });
   },
 };

--- a/new-era-commands/slash/code.js
+++ b/new-era-commands/slash/code.js
@@ -3,8 +3,11 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('code')
-    .setDescription('How to share your code'),
+    .setDescription('How to share your code')
+    .addUserOption((option) => option.setName('user').setDescription('user to ping')),
   execute: async (interaction) => {
+    const userId = interaction.options.getUser('user')?.id;
+
     const codeEmbed = new EmbedBuilder()
       .setColor('#cc9543')
       .setTitle('How to share your code')
@@ -30,6 +33,9 @@ For \`inline code\` use one backtick (no syntax highlighting):
 - [Codepen](https://codepen.io/) for basic HTML/CSS/Javascript
       `);
 
-    await interaction.reply({ embeds: [codeEmbed] });
+    await interaction.reply({
+      content: userId ? `<@${userId}>` : '',
+      embeds: [codeEmbed],
+    });
   },
 };

--- a/new-era-commands/slash/contribute.js
+++ b/new-era-commands/slash/contribute.js
@@ -3,8 +3,11 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('contribute')
-    .setDescription('Information on how to contribute to TOP on GitHub'),
+    .setDescription('Information on how to contribute to TOP on GitHub')
+    .addUserOption((option) => option.setName('user').setDescription('user to ping')),
   execute: async (interaction) => {
+    const userId = interaction.options.getUser('user')?.id;
+
     const contributingEmbed = new EmbedBuilder()
       .setColor('#cc9543')
       .setTitle('Contributing to The Odin Project Repositories')
@@ -20,11 +23,11 @@ To contribute to The Odin Project, check out our repositories on GitHub:
 
 Make sure to read the [contributing guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md) before getting started.
 
-To find issues ready to be worked on, go to the \`issues\` tab in each repository. You can also create new issues or propose suggestions there. 
+To find issues ready to be worked on, go to the \`issues\` tab in each repository. You can also create new issues or propose suggestions there.
 
 **First time contributors**
 
-If you're a first-time contributor, you can look for issues labeled \`good first issue\`. 
+If you're a first-time contributor, you can look for issues labeled \`good first issue\`.
 These are beginner-friendly and perfect for getting started with open source contributions.
 
 **Top-contributors role**
@@ -34,6 +37,9 @@ You will recognize our TOP-Contributors by their special role which you can lear
 We hope to see you on GitHub!
       `);
 
-    await interaction.reply({ embeds: [contributingEmbed] });
+    await interaction.reply({
+      content: userId ? `<@${userId}>` : '',
+      embeds: [contributingEmbed],
+    });
   },
 };

--- a/new-era-commands/slash/data.js
+++ b/new-era-commands/slash/data.js
@@ -3,8 +3,11 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('data')
-    .setDescription("Don't ask to ask!"),
+    .setDescription("Don't ask to ask!")
+    .addUserOption((option) => option.setName('user').setDescription('user to ping')),
   execute: async (interaction) => {
+    const userId = interaction.options.getUser('user')?.id;
+
     const dataEmbed = new EmbedBuilder()
       .setTitle('Don’t ask to ask!')
       .setColor('#cc9543')
@@ -21,12 +24,15 @@ Instead of asking if anyone can help you, ask your question outright with as muc
 **Lesson link:**
 **Code:** [code sandbox like replit or codepen]
 **Issue/Problem:** [screenshots if applicable]
-**What I expected:** 
-**What I've tried:** 
+**What I expected:**
+**What I've tried:**
 
 **https://www.dontasktoask.com/**
         `);
 
-    await interaction.reply({ embeds: [dataEmbed] });
+    await interaction.reply({
+      content: userId ? `<@${userId}>` : '',
+      embeds: [dataEmbed],
+    });
   },
 };

--- a/new-era-commands/slash/debug.js
+++ b/new-era-commands/slash/debug.js
@@ -3,8 +3,11 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('debug')
-    .setDescription('Debugging'),
+    .setDescription('Debugging')
+    .addUserOption((option) => option.setName('user').setDescription('user to ping')),
   execute: async (interaction) => {
+    const userId = interaction.options.getUser('user')?.id;
+
     const debugEmbed = new EmbedBuilder()
       .setColor('#cc9543')
       .setTitle('DEBUGGING')
@@ -24,6 +27,9 @@ module.exports = {
         ],
       );
 
-    await interaction.reply({ embeds: [debugEmbed] });
+    await interaction.reply({
+      content: userId ? `<@${userId}>` : '',
+      embeds: [debugEmbed],
+    });
   },
 };

--- a/new-era-commands/slash/freelance.js
+++ b/new-era-commands/slash/freelance.js
@@ -3,15 +3,21 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('freelancing')
-    .setDescription('Things to consider about freelancing'),
+    .setDescription('Things to consider about freelancing')
+    .addUserOption((option) => option.setName('user').setDescription('user to ping')),
   execute: async (interaction) => {
+    const userId = interaction.options.getUser('user')?.id;
+
     const freelanceEmbed = new EmbedBuilder()
       .setColor('#cc9543')
       .setTitle('Freelancing')
       .setDescription(`
-Here are some things that should be considered before getting into freelancing: https://discord.com/channels/505093832157691914/505093832157691916/928760451213443193 
+Here are some things that should be considered before getting into freelancing: https://discord.com/channels/505093832157691914/505093832157691916/928760451213443193
       `);
 
-    await interaction.reply({ embeds: [freelanceEmbed] });
+    await interaction.reply({
+      content: userId ? `<@${userId}>` : '',
+      embeds: [freelanceEmbed],
+    });
   },
 };

--- a/new-era-commands/slash/notes.js
+++ b/new-era-commands/slash/notes.js
@@ -3,8 +3,11 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('notes')
-    .setDescription('Things to consider about taking notes'),
+    .setDescription('Things to consider about taking notes')
+    .addUserOption((option) => option.setName('user').setDescription('user to ping')),
   execute: async (interaction) => {
+    const userId = interaction.options.getUser('user')?.id;
+
     const freelanceEmbed = new EmbedBuilder()
       .setColor('#cc9543')
       .setTitle('To note, or not to note, that is the question')
@@ -12,6 +15,9 @@ module.exports = {
 Please read this [Discord message about what we think you should consider about taking notes](https://discord.com/channels/505093832157691914/505093832157691916/768161823366578176)
       `);
 
-    await interaction.reply({ embeds: [freelanceEmbed] });
+    await interaction.reply({
+      content: userId ? `<@${userId}>` : '',
+      embeds: [freelanceEmbed],
+    });
   },
 };

--- a/new-era-commands/slash/portfolio.js
+++ b/new-era-commands/slash/portfolio.js
@@ -3,8 +3,11 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('portfolio')
-    .setDescription('Information about portfolio-worthy projects'),
+    .setDescription('Information about portfolio-worthy projects')
+    .addUserOption((option) => option.setName('user').setDescription('user to ping')),
   execute: async (interaction) => {
+    const userId = interaction.options.getUser('user')?.id;
+
     const portfolioEmbed = new EmbedBuilder()
       .setColor('#cc9543')
       .setTitle('Strategically Building Your Portfolio')
@@ -14,6 +17,9 @@ module.exports = {
 Read more on which projects are worth your extra time in
 [this article about strategically building your portfolio](https://dev.to/theodinproject/strategically-building-your-portfolio-1km4)
 `);
-    await interaction.reply({ embeds: [portfolioEmbed] });
+    await interaction.reply({
+      content: userId ? `<@${userId}>` : '',
+      embeds: [portfolioEmbed],
+    });
   },
 };

--- a/new-era-commands/slash/question.js
+++ b/new-era-commands/slash/question.js
@@ -3,24 +3,30 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('question')
-    .setDescription('Asking Great Questions'),
+    .setDescription('Asking Great Questions')
+    .addUserOption((option) => option.setName('user').setDescription('user to ping')),
   execute: async (interaction) => {
+    const userId = interaction.options.getUser('user')?.id;
+
     const questionEmbed = new EmbedBuilder()
       .setColor('#cc9543')
       .setTitle('Asking Great Questions')
       .setDescription(`
-Asking context-rich questions makes it easy to receive help, and makes it easy for others to help you quickly! Great engineers ask great questions, and the prompt below is an invitation to improve your skills and set yourself up for success in the workplace. 
+Asking context-rich questions makes it easy to receive help, and makes it easy for others to help you quickly! Great engineers ask great questions, and the prompt below is an invitation to improve your skills and set yourself up for success in the workplace.
 
 **Project/Exercise:**
 **Lesson link:**
 **Code:** [code sandbox like replit or codepen]
 **Issue/Problem:** [screenshots if applicable]
-**What I expected:** 
-**What I've tried:** 
+**What I expected:**
+**What I've tried:**
 
 For even more context around on how to hone your question-asking skills, give this a read: https://www.theodinproject.com/guides/community/how_to_ask
               `);
 
-    await interaction.reply({ embeds: [questionEmbed] });
+    await interaction.reply({
+      content: userId ? `<@${userId}>` : '',
+      embeds: [questionEmbed],
+     });
   },
 };

--- a/new-era-commands/slash/top.js
+++ b/new-era-commands/slash/top.js
@@ -3,8 +3,11 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('top')
-    .setDescription('Information about The Odin Project'),
+    .setDescription('Information about The Odin Project')
+    .addUserOption((option) => option.setName('user').setDescription('user to ping')),
   execute: async (interaction) => {
+    const userId = interaction.options.getUser('user')?.id;
+
     const topEmbed = new EmbedBuilder()
       .setColor('#cc9543')
       .setTitle('The Odin Project')
@@ -12,6 +15,10 @@ module.exports = {
 For more information about The Odin Project, visit our site:
 [Your Career in Web Development Starts Here](https://www.theodinproject.com/)
     `);
-    await interaction.reply({ embeds: [topEmbed] });
+
+    await interaction.reply({
+      content: userId ? `<@${userId}>` : '',
+      embeds: [topEmbed],
+    });
   },
 };

--- a/new-era-commands/slash/windows.js
+++ b/new-era-commands/slash/windows.js
@@ -3,14 +3,20 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('windows')
-    .setDescription('Windows'),
+    .setDescription('Windows')
+    .addUserOption((option) => option.setName('user').setDescription('user to ping')),
   execute: async (interaction) => {
+    const userId = interaction.options.getUser('user')?.id;
+
     const windowsEmbed = new EmbedBuilder()
       .setColor('#cc9543')
       .setTitle('Windows')
       .setDescription('**The Odin Project does not support Windows, WSL, or any OS outside of our recommendations**. We are happy to assist with any questions about installing a VM or dual booting Linux. <https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/installation-overview#os-options>')
       .setURL('https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/installation-overview#os-options');
 
-    await interaction.reply({ embeds: [windowsEmbed] });
+    await interaction.reply({
+      content: userId ? `<@${userId}>` : '',
+      embeds: [windowsEmbed],
+    });
   },
 };


### PR DESCRIPTION
## Because
Allows a user to be tagged in a slash command without the need to send an additional message.
Will be particularly convenient once the full switch to slash commands (bar exceptions) is made.


## This PR
- Added optional user mention to relevant slash commands, as per current `/google` and `/time` commands


## Issue
Closes #404

## Additional Information
N/A

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR adds new features or functionality, I have added new tests
-   [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
