### PR TITLE
Bot: create tutorialhell command

### DIFF
--- a/new-era-commands/slash/tutorialHell.js
+++ b/new-era-commands/slash/tutorialHell.js
@@ -1,0 +1,27 @@
+const { SlashCommandBuilder, EmbedBuilder } = require("discord.js");
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName("tutorialhell")
+    .setDescription("TOP's advice on doing more than one course at a time")
+    .addUserOption((option) =>
+      option.setName("user").setDescription("user to ping")
+    ),
+  execute: async (interaction) => {
+    const userId = interaction.options.getUser("user");
+    const tutorialHellEmbed = new EmbedBuilder()
+      .setColor("#cc9543")
+      .setTitle("TOP's advice on doing more than one course at a time")
+      .setDescription(`
+1. There is no "best" course when you're a self-learner. It's about learning yourself and not being handed the concepts. 
+2. Beginner content dominates learning resources, but excessive topic repetition, known as 'Tutorial Hell,' isn't helpful. Instead, focus on practice and progress. Concepts often become clearer over time. Using multiple courses simultaneously prolongs basic learning, by lacking the understanding to integrate the concepts fully. This wastes time. Switching courses can lead to context loss and increased repetition, further slowing you down. After learning, reinforce with practice, not mere topic reiteration.
+3. Different courses, different methods. Mixing them can confuse you and scatter your attention. This could extend your learning time or leave you with shallow knowledge. Following one course eliminates this.
+4. Finding help on topics in courses with a weak support community is difficult, and shifting this burden to another is rude and unlikely to be helpful.
+5. Undecided? Pick the course you feel you are most likely to complete. 
+      `);
+    await interaction.reply({
+      content: userId ? `${userId}` : "",
+      embeds: [tutorialHellEmbed],
+    });
+  },
+};


### PR DESCRIPTION


<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Benefit:

- Reduce friction to provide learners with what TOP recommends regarding topic
- Learners get consistent messaging.

Solves:

- Having to search for a pinned message, or taking the time to type out a response in the moment that paraphrases the advice contained in the pin.
- Less workload for those involved in moderating or even helping out in chat.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->

- creates /tutorialhell command
- optional user ping
- contains edited content discussed in issue

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #462 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->

- Summarized Briggs's messages on the topic, and added Carlos's message about picking a course and sticking with it, to be more directive for those who need that, and a bit more course agnostic. If someone feels that FCC or whatever is the best course for them, I am happy for them.

- I'm not in love with the numbering, but I felt like it might be nice to say to a user 'read number 2 in particular'.

- It's still a lot of content for one command. I shrunk Briggs's message by over 50%. I think the synergy of the points is important though, so unless a more succinct rewrite is possible, this works.

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If this PR adds new features or functionality, I have added new tests
-   [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
