### PR TITLE
UpdateFAQService: Split FAQ's by section

### DIFF
--- a/services/update-faq/update-faq.service.js
+++ b/services/update-faq/update-faq.service.js
@@ -4,6 +4,8 @@ const config = require('../../config');
 class UpdateFAQsService {
   static EmbedDescriptionCharacterLimit = 4096;
 
+  static Delimiter = '###'
+
   static async handleInteraction(interaction) {
     let rawFAQs;
     try {
@@ -29,7 +31,7 @@ class UpdateFAQsService {
 
   static createFAQEmbeds(rawFAQs) {
     return UpdateFAQsService
-      .segments(rawFAQs, UpdateFAQsService.EmbedDescriptionCharacterLimit)
+      .segments(rawFAQs, UpdateFAQsService.EmbedDescriptionCharacterLimit, UpdateFAQsService.Delimiter)
       .map((chunk) => new EmbedBuilder().setColor('#cc9543').setDescription(chunk));
   }
 
@@ -44,11 +46,29 @@ class UpdateFAQsService {
     prev.forEach((message) => message.delete());
   }
 
-  static segments(string, length) {
-    const segments = [];
-    for (let i = 0; i < string.length; i += length) {
-      segments.push(string.substring(i, i + length));
+  static segments(string, length, delimiter, doNotPrependDelimiter) {
+    const segmentedString = string.split(delimiter)
+    const segments = []
+    let currentSection = ""
+
+    for (let i = 0; i < segmentedString.length; i += 1) {
+      let segment = segmentedString[i]
+
+      if (!doNotPrependDelimiter) {
+        segment = delimiter + segmentedString[i]
+      }
+      if (segmentedString[i] === '') {
+        // eslint-disable-next-line no-continue
+        continue
+      }
+      if ((currentSection.length + segment.length) >= length) {
+          segments.push(currentSection)
+          currentSection = segment
+      } else {
+        currentSection += segment
+      }
     }
+    segments.push(currentSection)
     return segments;
   }
 }

--- a/services/update-faq/update-faq.service.test.js
+++ b/services/update-faq/update-faq.service.test.js
@@ -5,29 +5,73 @@ jest.spyOn(discordjs, 'EmbedBuilder');
 
 describe('UpdateFAQsService', () => {
   describe('segments', () => {
-    describe('when string size is divisible by segment length', () => {
+    describe('when string size is greater than segment length', () => {
       it('segments string correctly', () => {
-        const string = 'The Odin Project';
-        const length = 2;
-        const result = UpdateFAQsService.segments(string, length);
-        expect(result).toEqual(['Th', 'e ', 'Od', 'in', ' P', 'ro', 'je', 'ct']);
+        const string = '### The Odin Project.### Your Career in Web Development starts here';
+        const delimiter = '###'
+        const length = 25;
+        const result = UpdateFAQsService.segments(string, length, delimiter);
+        expect(result).toEqual(['### The Odin Project.', '### Your Career in Web Development starts here']);
       });
     });
-    describe('when string size is not divisible by segment length', () => {
-      it('segments string correctly', () => {
-        const string = 'The Odin Project';
-        const length = 3;
-        const result = UpdateFAQsService.segments(string, length);
-        expect(result).toEqual(['The', ' Od', 'in ', 'Pro', 'jec', 't']);
+
+    describe('when segment length is greater than string length', () => {
+      it('returns a single string', () => {
+        const string = '### The Odin Project.### Your Career in Web Development starts here';
+        const delimiter = '###'
+        const length = 75;
+        const result = UpdateFAQsService.segments(string, length, delimiter);
+        expect(result).toEqual(['### The Odin Project.### Your Career in Web Development starts here']);
       });
     });
+
     describe('when string size is 0', () => {
-      it('returns empty array', () => {
+      it('returns array containing empty string', () => {
         const string = '';
         const length = 2;
         const result = UpdateFAQsService.segments(string, length);
-        expect(result).toEqual([]);
+        expect(result).toEqual([""]);
       });
     });
+
+    describe('when different delimiters are used', () => {
+      it('returns the string with the correct delimiter', () => {
+        const string = '& The Odin Project.& Your Career in Web Development starts here';
+        const delimiter = '&'
+        const length = 25;
+        const result = UpdateFAQsService.segments(string, length, delimiter);
+        expect(result).toEqual(['& The Odin Project.', '& Your Career in Web Development starts here']);
+      })
+    })
+
+    describe('when delimiters shouldn\'t be prepended', () => {
+      it('returns the string without the delimiter', () => {
+        const string = '### The Odin Project.### Your Career in Web Development starts here';
+        const delimiter = '###'
+        const length = 25;
+        const result = UpdateFAQsService.segments(string, length, delimiter, true);
+        expect(result).toEqual([' The Odin Project.', ' Your Career in Web Development starts here']);
+      })
+    })
+
+    describe('when the delimiter isn\'t present', () => {
+      it('returns the full string with the delimiter prepended', () => {
+        const string = 'The Odin Project. Your Career in Web Development starts here';
+        const delimiter = '###'
+        const length = 75;
+        const result = UpdateFAQsService.segments(string, length, delimiter);
+        expect(result).toEqual(['###The Odin Project. Your Career in Web Development starts here']);
+      })
+    })
+
+    describe('when the delimiter isn\'t present and the delimiter shouldn\t be prepended', () => {
+      it('returns the full string', () => {
+        const string = 'The Odin Project. Your Career in Web Development starts here';
+        const delimiter = '###'
+        const length = 75;
+        const result = UpdateFAQsService.segments(string, length, delimiter, true);
+        expect(result).toEqual(['The Odin Project. Your Career in Web Development starts here']);
+      })
+    })
   });
 });


### PR DESCRIPTION
## Because
- The splitting algorithm cuts words in pieces


## This PR
- Rewrites it to split on a set delimiter instead
- Rewrites the tests to account for this


## Issue
Closes #456 

## Additional Information

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR adds new features or functionality, I have added new tests
-   [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
