### PR TITLE
feat: update rules service

### DIFF
--- a/config.js
+++ b/config.js
@@ -13,6 +13,7 @@ const config = {
     gettingHiredChannelId: process.env.DISCORD_GETTING_HIRED_CHANNEL_ID,
     botSpamPlaygroundChannelId: '513125912070455296',
     FAQChannelId: '823266307293839401',
+    rulesChannelId: '693244715839127653',
   },
   roles: {
     NOBOTRoleId: '783764176178774036',

--- a/new-era-commands/slash/update-rules.js
+++ b/new-era-commands/slash/update-rules.js
@@ -1,0 +1,12 @@
+const { SlashCommandBuilder, PermissionFlagsBits } = require("discord.js");
+const UpdateRulesService = require("../../services/update-rules/update-rules.service");
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName("updaterules")
+    .setDescription("update rules in the #rules channel")
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages),
+  execute: async (interaction) => {
+    await UpdateRulesService.handleInteraction(interaction);
+  },
+};

--- a/services/update-rules/index.js
+++ b/services/update-rules/index.js
@@ -1,0 +1,3 @@
+const UpdateRulesService = require("./update-rules.service");
+
+module.exports = UpdateRulesService;

--- a/services/update-rules/update-rules.service.js
+++ b/services/update-rules/update-rules.service.js
@@ -1,0 +1,81 @@
+const { EmbedBuilder } = require("discord.js");
+const config = require("../../config");
+
+class UpdateRulesService {
+  static EmbedDescriptionCharacterLimit = 4096;
+
+  // regex for [rule-name]: # (my rule name)
+  static Delimiter = /(\[rule-name\]: # \(.+\))/;
+
+  static async handleInteraction(interaction) {
+    let rawRules;
+    try {
+      rawRules = await UpdateRulesService.fetchRules();
+    } catch (error) {
+      console.log(error);
+      await interaction.reply("Failed to update rules");
+      return;
+    }
+
+    const rulesEmbeds = UpdateRulesService.createRulesEmbeds(rawRules);
+    const rulesChannel = interaction.guild.channels.cache.get(
+      config.channels.rulesChannelId
+    );
+    await UpdateRulesService.deletePreviousRules(rulesChannel);
+    await interaction.reply("i'm doing the thing, wait...");
+    await UpdateRulesService.sendRules(rulesEmbeds, rulesChannel);
+    await interaction.editReply("Rules updated");
+  }
+
+  static async fetchRules() {
+    const response = await fetch(
+      "https://raw.githubusercontent.com/TheOdinProject/top-meta/main/community-rules.md"
+    );
+    const rules = await response.text();
+    return rules;
+  }
+
+  static createRulesEmbeds(rawRules) {
+    return UpdateRulesService.segments(
+      rawRules,
+      UpdateRulesService.EmbedDescriptionCharacterLimit,
+      UpdateRulesService.Delimiter
+    ).map((chunk) =>
+      new EmbedBuilder().setColor("#cc9543").setDescription(chunk)
+    );
+  }
+
+  static async sendRules(rulesEmbeds, rulesChannel) {
+    await Promise.all(
+      rulesEmbeds.map(async (e) => {
+        await rulesChannel.send({ embeds: [e] });
+      })
+    );
+  }
+
+  static async deletePreviousRules(rulesChannel) {
+    // might need to increase limit if there are more than 20 messages
+    const prev = await rulesChannel.messages.fetch({ limit: 20 });
+    prev.forEach((message) => message.delete());
+  }
+
+  static segments(string, length, delimiter) {
+    const segmentedString = string
+      // for whatever reason, discord ain't parsing these emojis. fine i'll do it myself
+      .replaceAll("&#9989;", "✅")
+      .replaceAll("&#10060;", "❌")
+      .split(delimiter)
+      .filter((chunk) => !chunk.match(delimiter));
+
+    for (let i = 0; i < segmentedString.length; i += 1) {
+      if (segmentedString[i].length >= length) {
+        segmentedString[i] = segmentedString[i].match(
+          new RegExp(`.{1,${length}}`, "g")
+        );
+      }
+    }
+    return segmentedString.flat(Infinity);
+  }
+}
+
+module.exports = UpdateRulesService;


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->

might save time

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->

adds `updaterules` command similar to `updatefaq`

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [ ] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
-   [ ] The `Because` section summarizes the reason for this PR
-   [ ] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If this PR adds new features or functionality, I have added new tests
-   [ ] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
