### PR TITLE
/stuck: Replace attachment builder with Statically link

### DIFF
--- a/new-era-commands/slash/stuck.js
+++ b/new-era-commands/slash/stuck.js
@@ -1,5 +1,4 @@
-const { SlashCommandBuilder, EmbedBuilder, AttachmentBuilder } = require('discord.js');
-const { join } = require('path');
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -9,8 +8,6 @@ module.exports = {
   execute: async (interaction) => {
     const userId = interaction.options.getUser('user');
 
-    const stuckImage = new AttachmentBuilder(join(__dirname, 'images/stuck.jpg'));
-
     const stuckEmbed = new EmbedBuilder()
       .setColor('#cc9543')
       .setTitle('I\'m stuck - what can I do?')
@@ -19,12 +16,13 @@ Have a look through the following flowchart (click to enlarge) for guidance in h
 
 If you would like to ask for help, there is a very good question template you can find via the \`/question\` command which can help you include as much relevant context and structure your question in a way that makes it much easier for others to assist you.
       `)
-      .setImage('attachment://stuck.jpg');
+      .setImage(
+        'https://cdn.statically.io/gh/TheOdinProject/odin-bot-v2/03c97a193c751d1cdffa81c3d3bf84e00291cd26/new-era-commands/slash/images/stuck.jpg'
+      );
 
     await interaction.reply({
       content: userId ? `${userId}` : '',
       embeds: [stuckEmbed],
-      files: [stuckImage],
     });
   },
 };


### PR DESCRIPTION
## Because
Using the attachment builder direct from the source files will be too costly. Statically is the standard method to use images in these repos.


## This PR
- Replaces the `stuck.jpg` image via the AttachmentBuilder with a Statically CDN link


## Issue
N/A

## Additional Information
Relates to #497

Proof of testing:
![Proof of testing bot command with statically link](https://i.ibb.co/tL5tq8D/20240227-193337-screenshot.jpg)

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR adds new features or functionality, I have added new tests
-   [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
