### PR TITLE
Feat: Make Update FAQ segment logic more concise

### DIFF
--- a/services/update-faq/update-faq.service.js
+++ b/services/update-faq/update-faq.service.js
@@ -46,29 +46,28 @@ class UpdateFAQsService {
     prev.forEach((message) => message.delete());
   }
 
-  static segments(string, length, delimiter, doNotPrependDelimiter) {
+  static segments(string, length, delimiter, prependDelimiter = true) {
     const segmentedString = string.split(delimiter)
     const segments = []
     let currentSection = ""
 
     for (let i = 0; i < segmentedString.length; i += 1) {
-      let segment = segmentedString[i]
+      const segment = prependDelimiter ? delimiter + segmentedString[i] : segmentedString[i];
 
-      if (!doNotPrependDelimiter) {
-        segment = delimiter + segmentedString[i]
-      }
       if (segmentedString[i] === '') {
         // eslint-disable-next-line no-continue
-        continue
+        continue;
       }
+
       if ((currentSection.length + segment.length) >= length) {
-          segments.push(currentSection)
-          currentSection = segment
+        segments.push(currentSection);
+        currentSection = segment;
       } else {
-        currentSection += segment
+        currentSection += segment;
       }
     }
-    segments.push(currentSection)
+
+    segments.push(currentSection);
     return segments;
   }
 }

--- a/services/update-faq/update-faq.service.test.js
+++ b/services/update-faq/update-faq.service.test.js
@@ -49,7 +49,7 @@ describe('UpdateFAQsService', () => {
         const string = '### The Odin Project.### Your Career in Web Development starts here';
         const delimiter = '###'
         const length = 25;
-        const result = UpdateFAQsService.segments(string, length, delimiter, true);
+        const result = UpdateFAQsService.segments(string, length, delimiter, false);
         expect(result).toEqual([' The Odin Project.', ' Your Career in Web Development starts here']);
       })
     })
@@ -69,7 +69,7 @@ describe('UpdateFAQsService', () => {
         const string = 'The Odin Project. Your Career in Web Development starts here';
         const delimiter = '###'
         const length = 75;
-        const result = UpdateFAQsService.segments(string, length, delimiter, true);
+        const result = UpdateFAQsService.segments(string, length, delimiter, false);
         expect(result).toEqual(['The Odin Project. Your Career in Web Development starts here']);
       })
     })


### PR DESCRIPTION
## Because
- I was looking at this recently, and I wasn't entirely happy with how I wrote this


## This PR
- changes the delimiter switch to a sensible default of prepend unless said otherwise
- changes the adding code to a ternary instead of an if, and in doing so removes the weird double negation I had going on
- updates tests to account for this

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
