### PR TITLE
Prettier: Add .prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,16 @@
+{
+  "arrowParens": "always",
+  "bracketSpacing": true,
+  "bracketSameLine": false,
+  "endOfLine": "lf",
+  "htmlWhitespaceSensitivity": "css",
+  "insertPragma": false,
+  "printWidth": 80,
+  "proseWrap": "preserve",
+  "quoteProps": "as-needed",
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "useTabs": false
+}


### PR DESCRIPTION
## Because

Prettier is already a dependency and the JS files currently follow a consistent style.

This PR's rule set is the closest configuration for most of our files. At most, a small handful of files would end up formatted with some additional line breaks due to the `80` print width, but other rules should keep everything else as is. Most files should be unaffected.

This would help prevent contributions with inconsistent styles caused by contributors' local Prettier rules, if they have any. With a `.prettierrc`, their extensions would pick up the rule file and format using that instead.

## This PR

- Adds a top-level `.prettierrc`

## Issue

Closes #506

## Additional Information

N/A

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If this PR adds new features or functionality, I have added new tests
-   [ ] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
