### PR TITLE
Feature: Add prettier GH workflow (--check only)

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -4,7 +4,8 @@ on:
     paths:
       - '**/*.js'
       - '**/*.json'
-      - '**/*.ya?ml'
+      - '**/*.yml'
+      - '**/*.yaml'
 
 jobs:
   format_check:
@@ -18,7 +19,8 @@ jobs:
           files: |
             **/*.js
             **/*.json
-            **/*.ya?ml
+            **/*.yml
+            **/*.yaml
           separator: ' '
       - uses: creyD/prettier_action@v4.3
         with:

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,0 +1,26 @@
+name: Prettier
+on:
+  pull_request:
+    paths:
+      - '**/*.js'
+      - '**/*.json'
+      - '**/*.ya?ml'
+
+jobs:
+  format_check:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tj-actions/changed-files@v41
+        id: changed-files
+        with:
+          files: |
+            **/*.js
+            **/*.json
+            **/*.ya?ml
+          separator: ' '
+      - uses: creyD/prettier_action@v4.3
+        with:
+          dry: True
+          prettier_options: --check ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
## Because

Since we have Prettier as a dependency with a `.prettierrc` file and `format` npm script, it'd help to have a pull request workflow that checks all changed files for formatting issues (which can be fixed with a simple `npm run format -- <paths to files>`.

Left at a `--check` only workflow so any formatting that may need to be done can go in a separate commit for easier reviewing. If a `--write` workflow would be preferable, let me know.

If merged, I'll update the repo wiki with formatting instructions.


## This PR

- Adds a check-only Prettier GH workflow


## Issue

Closes #560

## Additional Information

Could not find a way to achieve this via CirclCI - could only find out how to get path filtering to allow an action to run on specific file change (and run `prettier --check .` on everything), rather than an action to only target changed files.


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If this PR adds new features or functionality, I have added new tests
-   [ ] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
