### PR TITLE
Chore: Points: Drop unused parameters from `getUserIdsFromMessage()`

### DIFF
--- a/botCommands/points.js
+++ b/botCommands/points.js
@@ -13,15 +13,7 @@ function gifPicker(gifContainer, clubChannel) {
   clubChannel.send(`Gif by ${gifContainer[choice].author}`);
 }
 
-function getUserIdsFromMessage(
-  client,
-  author,
-  guild,
-  text,
-  regex,
-  authorMember,
-  channel,
-) {
+function getUserIdsFromMessage(text, regex, authorMember, channel) {
   const matches = [];
   const processedIDs = [];
   let match = regex.exec(text);
@@ -128,9 +120,6 @@ const awardPoints = {
     member,
   }) {
     const userIds = getUserIdsFromMessage(
-      client,
-      author,
-      guild,
       content,
       new RegExp(
         `(?<!\\S)${userRegex}\\s?(${doublePointsPlusRegex}|${plusRegex}|${starRegex})(?!\\S)`,


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
- Some parameters aren't used by `getUserIdsFromMessage()`

## This PR
- Drops them

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date