### PR TITLE
/os: Amend title and body wording

### DIFF
--- a/botCommands/__snapshots__/os.test.js.snap
+++ b/botCommands/__snapshots__/os.test.js.snap
@@ -5,13 +5,12 @@ exports[`!os callback returns correct output 1`] = `
   "embeds": [
     {
       "color": 13407555,
-      "description": "**The Odin Project is not designed for and does not support Windows or any other OS outside of our recommendations**. We are happy to assist with any questions about installing a VM, using WSL, or dual booting Linux.
+      "description": "**The Odin Project is not designed for and does not support Windows or any other OS outside of our recommendations**. We are happy to assist with any questions about installing and using Ubuntu (or an official flavor) via a VM, WSL, or dual booting.
 
 For more info on Windows, check out this exhaustive list on [why we do not support Windows](<https://github.com/TheOdinProject/blog/wiki/Why-We-Do-Not-Support-Windows>).
 
-[You can find our list of OS options in the Installation Overview lesson](<https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/installation-overview#os-options>)",
-      "title": "Windows",
-      "url": "https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/installation-overview#os-options",
+You can find our list of supported OS options in our [Installation Overview lesson](<https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/installation-overview#os-options>).",
+      "title": "OS support",
     },
   ],
 }

--- a/botCommands/os.js
+++ b/botCommands/os.js
@@ -2,7 +2,7 @@ const Discord = require("discord.js");
 const { registerBotCommand } = require("../botEngine");
 const { os } = require("../lib/commandsContent");
 
-const { color, title, description, url } = os;
+const { color, title, description } = os;
 
 const command = {
   regex: /(?<!\S)!os(?!\S)/,
@@ -10,8 +10,7 @@ const command = {
     const osEmbed = new Discord.EmbedBuilder()
       .setColor(color)
       .setTitle(title)
-      .setDescription(description)
-      .setURL(url);
+      .setDescription(description);
 
     return { embeds: [osEmbed] };
   },

--- a/lib/commandsContent.js
+++ b/lib/commandsContent.js
@@ -34,7 +34,6 @@ For \`inline code\` use one backtick (no syntax highlighting):
 For more info on Windows, check out this exhaustive list on [why we do not support Windows](<https://github.com/TheOdinProject/blog/wiki/Why-We-Do-Not-Support-Windows>).
 
 You can find our list of supported OS options in our [Installation Overview lesson](<https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/installation-overview#os-options>).`,
-    url: 'https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/installation-overview#os-options',
   },
   question: {
     color,

--- a/lib/commandsContent.js
+++ b/lib/commandsContent.js
@@ -28,12 +28,12 @@ For \`inline code\` use one backtick (no syntax highlighting):
   },
   os: {
     color,
-    title: 'Windows',
-    description: `**The Odin Project is not designed for and does not support Windows or any other OS outside of our recommendations**. We are happy to assist with any questions about installing a VM, using WSL, or dual booting Linux.
+    title: 'OS support',
+    description: `**The Odin Project is not designed for and does not support Windows or any other OS outside of our recommendations**. We are happy to assist with any questions about installing and using Ubuntu (or an official flavor) via a VM, WSL, or dual booting.
 
 For more info on Windows, check out this exhaustive list on [why we do not support Windows](<https://github.com/TheOdinProject/blog/wiki/Why-We-Do-Not-Support-Windows>).
 
-[You can find our list of OS options in the Installation Overview lesson](<https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/installation-overview#os-options>)`,
+You can find our list of supported OS options in our [Installation Overview lesson](<https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/installation-overview#os-options>).`,
     url: 'https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/installation-overview#os-options',
   },
   question: {


### PR DESCRIPTION
## Because

The current `/os` command has "Windows" as a title - a carryover from when it used to be `/windows`? The embed text could also probably do with being explicit about what Linux distros we do support.

## This PR

- Amends `/os` command title to be OS-agnostic
- Amends `/os` embed wording and link text label
- Removes the url property from `!os` command to be consistent with other commands (not really used anyway since it just makes the title a link, and the embed already contains that link)
- Updates `/os` snapshots


## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
N/A

## Additional Information

![image](https://github.com/user-attachments/assets/9bcc2fb3-3f4d-4690-952b-a0b6a0565523)

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR adds new features or functionality, I have added new tests
-   [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
