### PR TITLE
Feat: Spam Ban: Also ban users who have left the server

### DIFF
--- a/services/spam-ban/__snapshots__/spam-banning.service.test.js.snap
+++ b/services/spam-ban/__snapshots__/spam-banning.service.test.js.snap
@@ -104,11 +104,11 @@ exports[`Banning spammer in different channels Does not ban user in different ch
 }
 `;
 
-exports[`Banning spammer that has left the server Reacts with the correct emoji to automod message 1`] = `"❌"`;
+exports[`Banning spammer that has left the server Reacts with the correct emoji to automod message 1`] = `"✅"`;
 
 exports[`Banning spammer that has left the server Sends back correct interaction reply to calling moderator 1`] = `
 {
-  "content": "Couldn't ban <@123>. User is not on the server.",
+  "content": "Banned <@123> for spam but wasn't able to contact the user as they have left the server.",
   "ephemeral": true,
 }
 `;


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because

#647 

## This PR

- Modifies the spam banning service to use `guild.members.ban()` for banning, which also allows banning user's who have left the server
- Modifies the rest of the code to account for this
- Slightly refactors some of the banning code
- Updates tests and snapshots
## Issue

<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->

Closes #647 

## Additional Information

<!-- Any other information about this PR, such as a link to a Discord discussion. -->

## Pull Request Requirements

<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->

- [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [x] If this PR addresses an open issue, it is linked in the `Issue` section
- [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
