### PR TITLE
DuplicateIdsError: Fix var name

### DIFF
--- a/utils/errors/duplicate-ids.js
+++ b/utils/errors/duplicate-ids.js
@@ -1,10 +1,11 @@
 class DuplicateIdsError extends Error {
-  constructor(missingIDs) {
+  constructor(duplicateIDs) {
     super(`
 Could not start Odin Bot locally. Each channel ID configured in config.js must be unique. The following IDs are duplicates:
-${missingIDs.join('\n')}
 
-You can modify what value the ID's are set to in the .env file. See .env for more information.`);
+${duplicateIDs.join('\n')}
+
+You can modify what value the IDs are set to in the .env file. See .env for more information.`);
 
     this.name = 'DuplicateIdsError';
   }


### PR DESCRIPTION

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because

<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Constructor param not changed after carryover from MissingEnvVarError class.

## This PR

<!-- A bullet point list of one or more items describing the specific changes. -->
- Renames constructor param
- Adds blank space for consistency with MissingEnvVarError message
- Removes unnecessary apostrophe

## Issue

<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->

N/A

## Additional Information

<!-- Any other information about this PR, such as a link to a Discord discussion. -->
:P

## Pull Request Requirements

<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->

- [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [x] If this PR addresses an open issue, it is linked in the `Issue` section
- [x] If this PR adds new features or functionality, I have added new tests
- [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
