### PR TITLE
chore: use flags for ephemeral messages

### DIFF
--- a/bot-commands/context-menu/format-code.js
+++ b/bot-commands/context-menu/format-code.js
@@ -2,7 +2,7 @@ const {
   ContextMenuCommandBuilder,
   ApplicationCommandType,
   PermissionFlagsBits,
-  MessageFlags
+  MessageFlags,
 } = require('discord.js');
 const FormatCodeService = require('../../services/format-code');
 

--- a/bot-commands/context-menu/format-code.js
+++ b/bot-commands/context-menu/format-code.js
@@ -2,6 +2,7 @@ const {
   ContextMenuCommandBuilder,
   ApplicationCommandType,
   PermissionFlagsBits,
+  MessageFlags
 } = require('discord.js');
 const FormatCodeService = require('../../services/format-code');
 
@@ -17,7 +18,7 @@ module.exports = {
       console.error(error);
       await interaction.reply({
         content: 'There was an error while executing this command!',
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
     }
   },

--- a/bot-commands/slash/opencollective.js
+++ b/bot-commands/slash/opencollective.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder } = require('discord.js');
+const { SlashCommandBuilder, MessageFlags } = require('discord.js');
 const OpenCollectiveService = require('../../services/opencollective');
 
 module.exports = {
@@ -20,7 +20,7 @@ module.exports = {
       console.error(error);
       await interaction.reply({
         content: 'Something went wrong. Please try again later.',
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
     }
   },

--- a/events/interaction-create.js
+++ b/events/interaction-create.js
@@ -16,7 +16,7 @@ module.exports = {
         console.error(error);
         await interaction.reply({
           content: 'There was an error while executing this command!',
-          flags: MessageFlags.Ephemeral
+          flags: MessageFlags.Ephemeral,
         });
       }
     }
@@ -27,7 +27,10 @@ module.exports = {
           await FormatCodeService.handleModalSubmit(interaction);
           return;
         }
-        interaction.reply({ content: 'Unknown modal submit', flags: MessageFlags.Ephemeral });
+        interaction.reply({
+          content: 'Unknown modal submit',
+          flags: MessageFlags.Ephemeral,
+        });
       } catch (error) {
         console.error(error);
         await interaction.reply({

--- a/events/interaction-create.js
+++ b/events/interaction-create.js
@@ -1,4 +1,4 @@
-const { Events } = require('discord.js');
+const { Events, MessageFlags } = require('discord.js');
 const { discordRegistrableCommands } = require('../bot-commands');
 const FormatCodeService = require('../services/format-code');
 
@@ -16,7 +16,7 @@ module.exports = {
         console.error(error);
         await interaction.reply({
           content: 'There was an error while executing this command!',
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral
         });
       }
     }
@@ -27,12 +27,12 @@ module.exports = {
           await FormatCodeService.handleModalSubmit(interaction);
           return;
         }
-        interaction.reply({ content: 'Unknown modal submit', ephemeral: true });
+        interaction.reply({ content: 'Unknown modal submit', flags: MessageFlags.Ephemeral });
       } catch (error) {
         console.error(error);
         await interaction.reply({
           content: 'There was an error while executing this command!',
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
     }

--- a/services/format-code/format-code.service.js
+++ b/services/format-code/format-code.service.js
@@ -4,7 +4,7 @@ const {
   TextInputBuilder,
   TextInputStyle,
   ActionRowBuilder,
-  MessageFlags
+  MessageFlags,
 } = require('discord.js');
 const prettierFormatter = require('./prettier-formatter');
 

--- a/services/format-code/format-code.service.js
+++ b/services/format-code/format-code.service.js
@@ -4,6 +4,7 @@ const {
   TextInputBuilder,
   TextInputStyle,
   ActionRowBuilder,
+  MessageFlags
 } = require('discord.js');
 const prettierFormatter = require('./prettier-formatter');
 
@@ -30,7 +31,7 @@ class FormatCodeService {
     if (!firstCodeBlock) {
       await FormatCodeService.sendMessage(interaction, {
         content: 'No codeblocks found.',
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
       return;
     }
@@ -67,7 +68,7 @@ class FormatCodeService {
     } catch (error) {
       await FormatCodeService.sendMessage(interaction, {
         content: error.message,
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
       return;
     }

--- a/services/format-code/format-code.service.test.js
+++ b/services/format-code/format-code.service.test.js
@@ -1,4 +1,5 @@
 const discordjs = require('discord.js');
+const { MessageFlags } = require('discord.js');
 const FormatCodeService = require('./format-code.service');
 
 // mock discord.js methods used in FormatCodeService
@@ -42,7 +43,7 @@ describe('FormatCodeService', () => {
           'mockInteraction',
           {
             content: 'Error',
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
           },
         );
       });

--- a/services/moderation-message-delete.service.js
+++ b/services/moderation-message-delete.service.js
@@ -1,5 +1,5 @@
 const { RESTJSONErrorCodes } = require('discord-api-types/v10');
-const { EmbedBuilder } = require('discord.js');
+const { EmbedBuilder, MessageFlags } = require('discord.js');
 const ThreadCreator = require('../utils/thread-creator');
 const { modmailUserId, channels } = require('../config');
 
@@ -10,7 +10,7 @@ class ModerationMessageDeleteService {
     if (!message || !message.deletable) {
       await ModerationMessageDeleteService.#interactionReply(interaction, {
         content: 'Message cannot be deleted. It may have been deleted already.',
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
       return;
     }
@@ -22,14 +22,14 @@ class ModerationMessageDeleteService {
       await ModerationMessageDeleteService.#interactionReply(interaction, {
         content:
           'Automod message deleted. This action did not affect the message that was flagged/blocked by Automod. You would want to use the app-delete command on the message directly to have the message deleted and member notified.',
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
       return;
     }
 
     await ModerationMessageDeleteService.#interactionReply(interaction, {
       content: 'Message deleted.',
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
 
     if (message.author.bot) return;

--- a/services/opencollective/opencollective.service.js
+++ b/services/opencollective/opencollective.service.js
@@ -1,6 +1,6 @@
+const { MessageFlags } = require('discord.js');
 const config = require('../../config');
 const RedisService = require('../redis');
-const { MessageFlags } = require('discord.js');
 
 class OpenCollectiveService {
   static API_URL = 'https://api.opencollective.com/graphql/v2';

--- a/services/opencollective/opencollective.service.js
+++ b/services/opencollective/opencollective.service.js
@@ -1,5 +1,6 @@
 const config = require('../../config');
 const RedisService = require('../redis');
+const { MessageFlags } = require('discord.js');
 
 class OpenCollectiveService {
   static API_URL = 'https://api.opencollective.com/graphql/v2';
@@ -17,7 +18,7 @@ class OpenCollectiveService {
     if (interaction.member.roles.cache.has(config.roles.backer)) {
       return interaction.reply({
         content: 'You already have the Backer role!',
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
     }
 
@@ -27,7 +28,7 @@ class OpenCollectiveService {
     if (await OpenCollectiveService.isUsernameCached(username, redis)) {
       return interaction.reply({
         content: OpenCollectiveService.failureMessage,
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
     }
 
@@ -37,7 +38,7 @@ class OpenCollectiveService {
     if (data.errors) {
       return interaction.reply({
         content: OpenCollectiveService.failureMessage,
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
     }
 
@@ -51,13 +52,13 @@ class OpenCollectiveService {
       await interaction.member.roles.add(config.roles.backer);
       return interaction.reply({
         content: OpenCollectiveService.successMessage,
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
     }
 
     return interaction.reply({
       content: OpenCollectiveService.failureMessage,
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
   }
 

--- a/services/spam-ban/__snapshots__/spam-banning.service.test.js.snap
+++ b/services/spam-ban/__snapshots__/spam-banning.service.test.js.snap
@@ -3,35 +3,35 @@
 exports[`Attempting to ban a bot or team member Does not ban admins 1`] = `
 {
   "content": "You do not have the permission to ban this user",
-  "ephemeral": true,
+  "flags": 64,
 }
 `;
 
 exports[`Attempting to ban a bot or team member Does not ban bots 1`] = `
 {
   "content": "You do not have the permission to ban this user",
-  "ephemeral": true,
+  "flags": 64,
 }
 `;
 
 exports[`Attempting to ban a bot or team member Does not ban core 1`] = `
 {
   "content": "You do not have the permission to ban this user",
-  "ephemeral": true,
+  "flags": 64,
 }
 `;
 
 exports[`Attempting to ban a bot or team member Does not ban maintainers 1`] = `
 {
   "content": "You do not have the permission to ban this user",
-  "ephemeral": true,
+  "flags": 64,
 }
 `;
 
 exports[`Attempting to ban a bot or team member Does not ban moderators 1`] = `
 {
   "content": "You do not have the permission to ban this user",
-  "ephemeral": true,
+  "flags": 64,
 }
 `;
 
@@ -79,28 +79,28 @@ exports[`Banning spammer in different channels Ban user if in the automod channe
 exports[`Banning spammer in different channels Ban user if in the automod channel 2`] = `
 {
   "content": "Successfully banned <@123> for spam.",
-  "ephemeral": true,
+  "flags": 64,
 }
 `;
 
 exports[`Banning spammer in different channels Does not ban user in different channels other than automod 1`] = `
 {
   "content": "This command can only be used in the automod block channel.",
-  "ephemeral": true,
+  "flags": 64,
 }
 `;
 
 exports[`Banning spammer in different channels Does not ban user in different channels other than automod 2`] = `
 {
   "content": "This command can only be used in the automod block channel.",
-  "ephemeral": true,
+  "flags": 64,
 }
 `;
 
 exports[`Banning spammer in different channels Does not ban user in different channels other than automod 3`] = `
 {
   "content": "This command can only be used in the automod block channel.",
-  "ephemeral": true,
+  "flags": 64,
 }
 `;
 
@@ -109,7 +109,7 @@ exports[`Banning spammer that has left the server Reacts with the correct emoji 
 exports[`Banning spammer that has left the server Sends back correct interaction reply to calling moderator 1`] = `
 {
   "content": "Banned <@123> for spam but wasn't able to contact the user as they have left the server.",
-  "ephemeral": true,
+  "flags": 64,
 }
 `;
 
@@ -124,7 +124,7 @@ exports[`Banning spammer who has DM set to private Reacts with the correct emoji
 exports[`Banning spammer who has DM set to private Sends back correct interaction reply to calling moderator 1`] = `
 {
   "content": "Banned <@123> for spam but wasn't able to contact the user.",
-  "ephemeral": true,
+  "flags": 64,
 }
 `;
 
@@ -172,7 +172,7 @@ exports[`Banning spammer with DM enabled Discord ban api is called with the corr
 exports[`Banning spammer with DM enabled Discord ban api is called with the correct reason 2`] = `
 {
   "content": "Successfully banned <@123> for spam.",
-  "ephemeral": true,
+  "flags": 64,
 }
 `;
 
@@ -203,7 +203,7 @@ exports[`Banning spammer with DM enabled Reacts with the correct emoji 1`] = `"â
 exports[`Banning spammer with DM enabled Sends back correct interaction reply to calling moderator 1`] = `
 {
   "content": "Successfully banned <@123> for spam.",
-  "ephemeral": true,
+  "flags": 64,
 }
 `;
 

--- a/services/spam-ban/spam-banning.service.js
+++ b/services/spam-ban/spam-banning.service.js
@@ -1,4 +1,4 @@
-const { EmbedBuilder } = require('discord.js');
+const { EmbedBuilder, MessageFlags } = require('discord.js');
 const { isAdmin } = require('../../utils/is-admin');
 const config = require('../../config');
 
@@ -10,7 +10,7 @@ class SpamBanningService {
       if (message.author.bot || isAdmin(message.member)) {
         interaction.reply({
           content: 'You do not have the permission to ban this user',
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
         return;
       }
@@ -18,12 +18,12 @@ class SpamBanningService {
         interaction.reply({
           content:
             'This command can only be used in the automod block channel.',
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
         return;
       }
       const reply = await SpamBanningService.#banUser(interaction);
-      interaction.reply({ content: reply, ephemeral: true });
+      interaction.reply({ content: reply, flags: MessageFlags.Ephemeral });
       await SpamBanningService.#announceBan(interaction, message);
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because

<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
 Supplying "ephemeral" for interaction response options is deprecated. Utilize flags instead.
## This PR

<!-- A bullet point list of one or more items describing the specific changes. -->
- All instances where "ephemeral" is used as an option are updated to use flags instead.
- importing MessageFlags class
- after changing all the instances , ran npm test -- -u (which changed "ephemeral": true to "flags": 64 in snapshots)
- all tests passes

> [!NOTE]
> i am on the ruby course and i don't know about jest and importing in js , so i could have made some obvious mistake...

## Issue

<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->

Closes #692 

## Additional Information

<!-- Any other information about this PR, such as a link to a Discord discussion. -->
nil
## Pull Request Requirements

<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->

- [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [x] If this PR addresses an open issue, it is linked in the `Issue` section
- [x] If this PR adds new features or functionality, I have added new tests
- [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
