### PR TITLE
Fix: Migrate husky hooks to v9 format

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
 lint-staged
+npm run test

--- a/package.json
+++ b/package.json
@@ -35,11 +35,6 @@
     "lint-staged": "^15.5.0",
     "nodemon": "^3.1.9"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged && npm run test"
-    }
-  },
   "lint-staged": {
     "*.js": "npx eslint"
   }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,15 @@
     "nodemon": "^3.1.9"
   },
   "lint-staged": {
-    "*.js": "npx eslint"
+    "!(*.js)": "prettier --check",
+    "!(*test).js": [
+      "prettier --check",
+      "eslint"
+    ],
+    "*test.js": [
+      "prettier --check",
+      "eslint",
+      "npm run test"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "prepare": "husky",
     "start": "node index.js",
     "dev": "nodemon index.js",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",

--- a/package.json
+++ b/package.json
@@ -37,14 +37,9 @@
   },
   "lint-staged": {
     "!(*.js)": "prettier --check",
-    "!(*test).js": [
+    "*.js": [
       "prettier --check",
       "eslint"
-    ],
-    "*test.js": [
-      "prettier --check",
-      "eslint",
-      "npm run test"
     ]
   }
 }


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because

The current installed Husky version is v9 but `package.json` contains the old v4 way of setting hooks. This doesn't work in v9 so `lint-staged` was never being run pre-commit. While we already have GH workflows for the same actions, it helps to have this at the local level too and reduce "appease linter/formatter" commits. Belts and braces.

## This PR

<!-- A bullet point list of one or more items describing the specific changes. -->
- Migrates to husky v9 way of setting a pre-commit hook
- Adds `prepare` npm script to ensure `npm install` also initialises husky (its setup files include a `.gitignore` that ignores themselves) https://typicode.github.io/husky/how-to.html#manual-setup
- Amends `lint-staged` tasks for different file types to also include Prettier

## Issue

<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->

N/A

## Additional Information

Example trying to commit a single change to `index.js` that includes a `let foo;` somewhere.

Current behaviour:

![image](https://github.com/user-attachments/assets/26af0977-ad8b-468e-b508-843ff8861128)

With PR fix:

![image](https://github.com/user-attachments/assets/a8b62956-59d8-4245-a336-a06f7294a870)

## Pull Request Requirements

<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->

- [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [x] If this PR addresses an open issue, it is linked in the `Issue` section
- [x] If this PR adds new features or functionality, I have added new tests
- [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
