### PR TITLE
Points regex: Loosen pattern matching to reduce need for duplicate pings

### DIFF
--- a/bot-commands/points/award-points.js
+++ b/bot-commands/points/award-points.js
@@ -93,15 +93,27 @@ const starRegex = '\u{2b50}';
 // matches at least two plus signs
 const plusRegex = '(\\+){2,}';
 const doublePointsPlusRegex = '\\?(\\+){2,}';
+const pointsCharsRegex = `(${plusRegex}|${doublePointsPlusRegex}|${starRegex})`;
+
+// https://regexr.com/8gd0p to test this regex
+//
+// Ensure the user mention is not escaped or encased directly in an inline code block
+//
+// Word chars disallowed after points chars to prevent awarding points if a user pings
+// someone to ask about pre-increment syntax, e.g. "hey @odinbot ++i increments then evaluates, right?"
+// but will still allow stuff like punctuation e.g. "thanks @odinbot ++!"
+//
+// Not so simple to detect and prevent user mentions deeper within an inline or fenced code block
+// But this is mostly prevented by Discord escaping user mentions when typing in them, so they won't match userRegex
+// Still technically possible by manually pasting something like <@!123456789> ++ in a code block (though it always was)
+const fullAwardPointsRegex = new RegExp(
+  `(?<!\\\\|\`)${userRegex}\\s*${pointsCharsRegex}(?!\\w)`,
+  'gu',
+);
 
 const awardPoints = {
   name: 'award points',
-  // uses a negative lookback to isolate the command
-  // followed by the Discord User, a whitespace character and either the star or plus incrementer
-  regex: new RegExp(
-    `(?<!\\S)${userRegex}\\s?(${doublePointsPlusRegex}|${plusRegex}|${starRegex})(?!\\S)`,
-    'gu',
-  ),
+  regex: fullAwardPointsRegex,
   cb: async function pointsBotCommand({
     author,
     content,
@@ -112,10 +124,7 @@ const awardPoints = {
   }) {
     const userIds = getUserIdsFromMessage(
       content,
-      new RegExp(
-        `(?<!\\S)${userRegex}\\s?(${doublePointsPlusRegex}|${plusRegex}|${starRegex})(?!\\S)`,
-        'gu',
-      ),
+      fullAwardPointsRegex,
       member,
       channel,
     );

--- a/bot-commands/points/points.test.js
+++ b/bot-commands/points/points.test.js
@@ -92,10 +92,14 @@ describe('award points', () => {
 
   describe('regex ++', () => {
     it.each([
+      ['<@!123456789>++'],
       ['<@!123456789> ++'],
       ['<@!123456789> +++'],
       ['<@!123456789> ++++++++++++'],
+      ['thanks<@!123456789> ++'],
       ['thanks <@!123456789> ++'],
+      ['thanks <@!123456789>      ++'],
+      ['thanks <@!123456789>                 ++'],
     ])("%s' - triggers the callback", (string) => {
       expect(string.match(awardPoints.regex)).toBeTruthy();
     });
@@ -107,7 +111,7 @@ describe('award points', () => {
       [' /'],
       ['odin-bot++'],
       ['/++'],
-      ['```function("<@!123456789> ++", () => {}```'],
+      ['`<@!123456789> ++`'],
     ])("'%s' does not trigger the callback", (string) => {
       expect(string.match(awardPoints.regex)).toBeFalsy();
     });
@@ -122,26 +126,44 @@ describe('award points', () => {
     });
 
     it.each([
-      ['@user/ ++'],
-      ["it's about/<@!123456789> ++"],
-      ['<@!123456789> ++isanillusion'],
+      ['<@!123456789> ++!'],
       ['<@!123456789> ++/'],
-      ['<@!123456789> ++*'],
+      ['<@!123456789> ++,'],
       ['<@!123456789> ++...'],
     ])(
-      "'%s' - command should be its own word/group - no leading or trailing characters",
+      "'%s' - command can be immediately followed by a non-word character",
+      (string) => {
+        expect(string.match(awardPoints.regex)).toBeTruthy();
+      },
+    );
+
+    it.each([
+      ['<@!123456789> ++i'], // e.g. prevents points if pinging to ask about pre-increment syntax
+      ['<@!123456789> ++yes'],
+      ['<@!123456789> ++_'],
+      ['<@!123456789> ++8'],
+    ])(
+      "'%s' - command cannot be immediately followed by a word character",
       (string) => {
         expect(string.match(awardPoints.regex)).toBeFalsy();
       },
     );
+
+    it('does not match if the user mention is escaped', () => {
+      expect('\\<@!123456789> ++'.match(awardPoints.regex)).toBeFalsy();
+    });
   });
 
   describe('regex ?++', () => {
     it.each([
+      ['<@!123456789>?++'],
       ['<@!123456789> ?++'],
       ['<@!123456789> ?+++'],
       ['<@!123456789> ?++++++++++++'],
+      ['<@!123456789>     ?++++++++++++'],
+      ['<@!123456789>          ?++++++++++++'],
       ['thanks <@!123456789> ?++'],
+      ['thanks<@!123456789> ?++'],
     ])("%s' - triggers the callback", (string) => {
       expect(string.match(awardPoints.regex)).toBeTruthy();
     });
@@ -153,7 +175,7 @@ describe('award points', () => {
       [' /'],
       ['odin-bot?++'],
       ['/?++'],
-      ['```function("<@!123456789> ?++", () => {}```'],
+      ['`<@!123456789> ?++`'],
     ])("'%s' does not trigger the callback", (string) => {
       expect(string.match(awardPoints.regex)).toBeFalsy();
     });
@@ -168,27 +190,32 @@ describe('award points', () => {
     });
 
     it.each([
-      ['@user/ ?++'],
-      ["it's about/<@!123456789> ?++"],
-      ['<@!123456789> ?++isanillusion'],
+      ['<@!123456789> ?++!'],
       ['<@!123456789> ?++/'],
-      ['<@!123456789> ?++*'],
+      ['<@!123456789> ?++,'],
       ['<@!123456789> ?++...'],
     ])(
-      "'%s' - command should be its own word/group - no leading or trailing characters",
-      (string) => {
-        expect(string.match(awardPoints.regex)).toBeFalsy();
-      },
-    );
-  });
-
-  describe('regex ⭐', () => {
-    it.each([['<@!123456789> ⭐'], ['thanks <@!123456789> ⭐']])(
-      "'%s' - correct strings trigger the callback",
+      "'%s' - command can be immediately followed by a non-word character",
       (string) => {
         expect(string.match(awardPoints.regex)).toBeTruthy();
       },
     );
+
+    it('does not match if the user mention is escaped', () => {
+      expect('\\<@!123456789> ?++'.match(awardPoints.regex)).toBeFalsy();
+    });
+  });
+
+  describe('regex ⭐', () => {
+    it.each([
+      ['<@!123456789>⭐'],
+      ['<@!123456789> ⭐'],
+      ['<@!123456789>     ⭐'],
+      ['thanks <@!123456789> ⭐'],
+      ['thanks<@!123456789> ⭐'],
+    ])("'%s' - correct strings trigger the callback", (string) => {
+      expect(string.match(awardPoints.regex)).toBeTruthy();
+    });
 
     it.each([
       ['⭐'],
@@ -197,7 +224,7 @@ describe('award points', () => {
       [' /'],
       ['odin-bot⭐'],
       ['/⭐'],
-      ['```function("<@!123456789> ⭐", () => {}```'],
+      ['`<@!123456789> ⭐`'],
     ])("'%s' does not trigger the callback", (string) => {
       expect(string.match(awardPoints.regex)).toBeFalsy();
     });
@@ -212,18 +239,20 @@ describe('award points', () => {
     });
 
     it.each([
-      ['@user/++'],
-      ["it's about/<@!123456789> ⭐"],
-      ['<@!123456789> ⭐isanillusion'],
+      ['<@!123456789> ⭐!'],
       ['<@!123456789> ⭐/'],
-      ['<@!123456789> ⭐*'],
+      ['<@!123456789> ⭐,'],
       ['<@!123456789> ⭐...'],
     ])(
-      "'%s' - command should be its own word/group - no leading or trailing characters",
+      "'%s' - command can be immediately followed by a non-word character",
       (string) => {
-        expect(string.match(awardPoints.regex)).toBeFalsy();
+        expect(string.match(awardPoints.regex)).toBeTruthy();
       },
     );
+
+    it('does not match if the user mention is escaped', () => {
+      expect('\\<@!123456789> ⭐'.match(awardPoints.regex)).toBeFalsy();
+    });
   });
 });
 


### PR DESCRIPTION
## Because

Common "errors" when awarding points in Discord:

- Autocompleting a ping automatically puts a space at the end. The user then enters a space then ++, leading to the bot not matching and awarding the point (due to 2 spaces in-between).
- User adds punctuation after ++ e.g. `Thanks @ping ++!` or `Thanks @ping ++, @pong ++`. Also not matched by the bot, so no points.
- User pings immediately after a word e.g. `Thanks@ping ++` (where the ping actually registers as a real ping and not escaped text, e.g. do the ping, then move cursor back to add text before the ping).

The current pattern matching doesn't *need* to be quite so strict. I haven't really seen any point awarding syntax that *must* be caught by the stricter pattern but allowed by this looser one. Though if it suddenly becomes a problem, things can always be amended again.

## This PR

- Amends `points.test.js` with looser pattern matching tests
- Amends awardPoints regex for looser pattern matching
- Extracts regex to variable for use in multiple places in the command function
- Adds comment explaining reasons for the pattern set

## Issue

Closes #729

## Additional information

Not simple to catch points awarding within code blocks (especially if nested inside) e.g.
````md
```js
function foo() {
    <@!123456789> ++
}
```
````
This was always allowed by the previous regex but is a highly improbably scenario anyway, since you'd have to manually paste `<@!123456789> ++` in to avoid Discord's auto-escape.
e.g. typing normally, `@odinbot` would stay as just `@odinbot` and not converted to the underlying ping chars. Same if it gets wrapped in a codeblock - the ping gets escaped to `@odinbot` instead of the real ping chars.

Should be fine to leave this be.


## Pull Request Requirements

- [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [x] If this PR addresses an open issue, it is linked in the `Issue` section
- [x] If this PR adds new features or functionality, I have added new tests
- [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
