### PR TITLE
message-create: Comment on importance of callback message arg

### DIFF
--- a/events/message-create.js
+++ b/events/message-create.js
@@ -78,6 +78,9 @@ module.exports = {
       if (message.content.toLowerCase().match(regex)) {
         authorBuffer.push(createAuthorEntry(message));
         try {
+          // Don't be an idiot like me and remove the callback's message arg
+          // Even if none of the ! commands use it, award-points does.
+          // - Mao
           const response = await fn(message);
           if (response) {
             try {


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because

<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Removing the non-slash botCommand callback `message` arg breaks award-points (#735) but since the award-points callback is tested directly, no tests failed when this was removed in (#732).

Discord.js isn't so easy to mock in terms of mock-sending a message and asserting the award-points callback is called with certain params (probably why the testing is handled by calling the callback directly in the tests), so I struggled to find a way to write a regression test for this situation.

Therefore, the next best thing is adding a comment warning that it should not be removed and why, in case this happens in the future. It's possible, since someone *could* forget that award-points is also part of the non-slash botCommands, not just the legacy `!` inline commands.

## This PR

<!-- A bullet point list of one or more items describing the specific changes. -->
- Adds comment warning about importance of botCommands callback `message` arg

## Issue

<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->

N/A

## Additional Information

<!-- Any other information about this PR, such as a link to a Discord discussion. -->

## Pull Request Requirements

<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->

- [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [x] If this PR addresses an open issue, it is linked in the `Issue` section
- [x] If this PR adds new features or functionality, I have added new tests
- [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
