### PR TITLE
Rotations: Put current active rotation member at start of queue

### DIFF
--- a/services/redis/__mocks__/redis.service.js
+++ b/services/redis/__mocks__/redis.service.js
@@ -33,6 +33,10 @@ class MockRedisInstance {
   async lpop(keyName) {
     return this.store[keyName].shift();
   }
+
+  async lindex(keyName, index) {
+    return this.store[keyName][index];
+  }
 }
 
 const MockRedisService = {

--- a/services/rotations/rotation.service.js
+++ b/services/rotations/rotation.service.js
@@ -110,9 +110,10 @@ class RotationService {
   }
 
   async #rotateQueue() {
-    const memberToPing = await this.redis.lpop(this.keyName);
-    await this.#addMembers([memberToPing]);
+    const previousMember = await this.redis.lpop(this.keyName);
+    await this.#addMembers([previousMember]);
 
+    const memberToPing = await this.redis.lindex(this.keyName, 0);
     return memberToPing;
   }
 

--- a/services/rotations/rotation.service.js
+++ b/services/rotations/rotation.service.js
@@ -2,9 +2,9 @@ const { escapeMarkdown } = require('discord.js');
 const RedisService = require('../redis');
 
 class RotationService {
-  constructor(keyName, rotationName) {
-    this.keyName = keyName;
+  constructor(rotationName, keyName) {
     this.rotationName = rotationName;
+    this.keyName = keyName;
     this.redis = RedisService.getInstance();
   }
 

--- a/services/rotations/rotation.service.js
+++ b/services/rotations/rotation.service.js
@@ -44,14 +44,13 @@ class RotationService {
       members,
       interaction.guild,
     );
-    const formattedQueue = membersDisplayNames.reduce(
-      (acc, displayname) => `${acc} ${displayname} >`,
-      '',
-    );
-    if (formattedQueue) {
-      return `${this.rotationName} rotation queue order:${formattedQueue}`;
-    }
-    return 'No members';
+    const formattedQueue = membersDisplayNames
+      .map((name, i) => `${name} ${i === 0 ? '(current) >' : '>'}`)
+      .join(' ');
+
+    return formattedQueue
+      ? `${this.rotationName} rotation queue order: ${formattedQueue}`
+      : 'No members';
   }
 
   async #handleAddMembers(members, interaction) {

--- a/services/rotations/rotation.service.test.js
+++ b/services/rotations/rotation.service.test.js
@@ -19,7 +19,7 @@ describe('addition', () => {
     await rotation.handleInteraction(interaction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@1234> <@5678> successfully added to the queue\n\ntest rotation queue order: Foo > Baz >',
+      '<@1234> <@5678> successfully added to the queue\n\ntest rotation queue order: Foo (current) > Baz >',
     );
   });
 
@@ -49,7 +49,7 @@ describe('addition', () => {
     await rotation.handleInteraction(additionInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@9101> successfully added to the queue\n\ntest rotation queue order: Foo > Baz > Bang >',
+      '<@9101> successfully added to the queue\n\ntest rotation queue order: Foo (current) > Baz > Bang >',
     );
   });
 
@@ -79,7 +79,7 @@ describe('addition', () => {
     await rotation.handleInteraction(additionInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@9101> <@1121> successfully added to the queue\n\ntest rotation queue order: Foo > Baz > Bang > Bing >',
+      '<@9101> <@1121> successfully added to the queue\n\ntest rotation queue order: Foo (current) > Baz > Bang > Bing >',
     );
   });
 
@@ -109,7 +109,7 @@ describe('addition', () => {
     await rotation.handleInteraction(additionInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      'Baz not added as they are already in the queue\n\n <@9101> <@1121> successfully added to the queue\n\ntest rotation queue order: Foo > Baz > Bang > Bing >',
+      'Baz not added as they are already in the queue\n\n <@9101> <@1121> successfully added to the queue\n\ntest rotation queue order: Foo (current) > Baz > Bang > Bing >',
     );
   });
 
@@ -142,7 +142,7 @@ describe('addition', () => {
     await rotation.handleInteraction(additionInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      'Bar not added as they are already in the queue\n\ntest rotation queue order: Bar > Baz >',
+      'Bar not added as they are already in the queue\n\ntest rotation queue order: Bar (current) > Baz >',
     );
   });
 
@@ -189,7 +189,7 @@ describe('addition', () => {
     await rotation.handleInteraction(interaction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@1234> <@5678> successfully added to the queue\n\ntest rotation queue order: Foo \\`test\\` > Baz \\*test\\* >',
+      '<@1234> <@5678> successfully added to the queue\n\ntest rotation queue order: Foo \\`test\\` (current) > Baz \\*test\\* >',
     );
   });
 });
@@ -221,7 +221,7 @@ describe('removal', () => {
     await rotation.handleInteraction(removalInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@1234> removed from the queue\n\ntest rotation queue order: Baz > Bang >',
+      '<@1234> removed from the queue\n\ntest rotation queue order: Baz (current) > Bang >',
     );
   });
 
@@ -251,7 +251,7 @@ describe('removal', () => {
     await rotation.handleInteraction(removalInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@5678> removed from the queue\n\ntest rotation queue order: Foo > Bang >',
+      '<@5678> removed from the queue\n\ntest rotation queue order: Foo (current) > Bang >',
     );
   });
 
@@ -281,7 +281,7 @@ describe('removal', () => {
     await rotation.handleInteraction(removalInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@9101> removed from the queue\n\ntest rotation queue order: Foo > Baz >',
+      '<@9101> removed from the queue\n\ntest rotation queue order: Foo (current) > Baz >',
     );
   });
 
@@ -343,7 +343,7 @@ describe('removal', () => {
     await rotation.handleInteraction(removalInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@5678> removed from the queue\n\ntest rotation queue order: Foo \\`test\\` >',
+      '<@5678> removed from the queue\n\ntest rotation queue order: Foo \\`test\\` (current) >',
     );
   });
 });
@@ -375,7 +375,7 @@ describe('swapping', () => {
     await rotation.handleInteraction(swappingInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@1234> <@9101> swapped position in the queue\n\ntest rotation queue order: Bang > Baz > Foo >',
+      '<@1234> <@9101> swapped position in the queue\n\ntest rotation queue order: Bang (current) > Baz > Foo >',
     );
   });
 
@@ -405,7 +405,7 @@ describe('swapping', () => {
     await rotation.handleInteraction(swappingInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@1234> <@5678> swapped position in the queue\n\ntest rotation queue order: Baz > Foo > Bang >',
+      '<@1234> <@5678> swapped position in the queue\n\ntest rotation queue order: Baz (current) > Foo > Bang >',
     );
   });
 
@@ -435,7 +435,7 @@ describe('swapping', () => {
     await rotation.handleInteraction(swappingInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@5678> <@9101> swapped position in the queue\n\ntest rotation queue order: Foo > Bang > Baz >',
+      '<@5678> <@9101> swapped position in the queue\n\ntest rotation queue order: Foo (current) > Bang > Baz >',
     );
   });
 
@@ -491,7 +491,7 @@ describe('swapping', () => {
     await rotation.handleInteraction(swapInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@1234> <@5678> swapped position in the queue\n\ntest rotation queue order: Baz \\*test\\* > Foo \\`test\\` >',
+      '<@1234> <@5678> swapped position in the queue\n\ntest rotation queue order: Baz \\*test\\* (current) > Foo \\`test\\` >',
     );
   });
 });
@@ -517,7 +517,7 @@ describe('reading', () => {
     await rotation.handleInteraction(readInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      'test rotation queue order: Foo > Baz > Bang >',
+      'test rotation queue order: Foo (current) > Baz > Bang >',
     );
   });
 
@@ -567,7 +567,7 @@ describe('reading', () => {
     await rotation.handleInteraction(readInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      'test rotation queue order: Foo \\`test\\` > Baz \\*test\\* >',
+      'test rotation queue order: Foo \\`test\\` (current) > Baz \\*test\\* >',
     );
   });
 });
@@ -593,7 +593,7 @@ describe('rotation', () => {
     await rotation.handleInteraction(rotationInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      "<@1234> it's your turn for the test rotation.\n\ntest rotation queue order: Baz > Bang > Foo >",
+      "<@1234> it's your turn for the test rotation.\n\ntest rotation queue order: Baz (current) > Bang > Foo >",
     );
   });
 
@@ -643,7 +643,7 @@ describe('rotation', () => {
     await rotation.handleInteraction(rotateInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      "<@1234> it's your turn for the test rotation.\n\ntest rotation queue order: Baz \\*test\\* > Foo \\`test\\` >",
+      "<@1234> it's your turn for the test rotation.\n\ntest rotation queue order: Baz \\*test\\* (current) > Foo \\`test\\` >",
     );
   });
 });

--- a/services/rotations/rotation.service.test.js
+++ b/services/rotations/rotation.service.test.js
@@ -573,7 +573,7 @@ describe('reading', () => {
 });
 
 describe('rotation', () => {
-  it('pings the user up in the rotation, rotates the queue, and reports the new queue order', async () => {
+  it('rotates the queue, pings the new first user in the rotation then reports the new queue order', async () => {
     const rotation = new RotationService('test', 'test');
 
     const creationUsers = getUsers(3);
@@ -593,7 +593,7 @@ describe('rotation', () => {
     await rotation.handleInteraction(rotationInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      "<@1234> it's your turn for the test rotation.\n\ntest rotation queue order: Baz (current) > Bang > Foo >",
+      "<@5678> it's your turn for the test rotation.\n\ntest rotation queue order: Baz (current) > Bang > Foo >",
     );
   });
 
@@ -643,7 +643,7 @@ describe('rotation', () => {
     await rotation.handleInteraction(rotateInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      "<@1234> it's your turn for the test rotation.\n\ntest rotation queue order: Baz \\*test\\* (current) > Foo \\`test\\` >",
+      "<@5678> it's your turn for the test rotation.\n\ntest rotation queue order: Baz \\*test\\* (current) > Foo \\`test\\` >",
     );
   });
 });

--- a/utils/rotation-builder.js
+++ b/utils/rotation-builder.js
@@ -34,7 +34,7 @@ function rotationBuilder(rotationName, redisKeyName) {
   const data = addSubcommands(base, subcommands);
 
   async function execute(interaction) {
-    const triageService = new RotationService(redisKeyName, rotationName);
+    const triageService = new RotationService(rotationName, redisKeyName);
     await triageService.handleInteraction(interaction);
   }
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because

<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
The current way of doing the queue when rotating is a little unintuitive.

Current, rotating first pings then rotates the queue, so the active member is placed at the end.
If user C is the active member, the queue will show
`A > B > C >`
When they rotate, user A will become the new active member but the queue will then show
`B > C > A >`

Instead, it'd be more intuitive for the active member to be at the start
If user C is the active member, the queue will show
`C > A > B >`
When they rotate and user A becomes the new active member:
`A > B > C >`


## This PR

<!-- A bullet point list of one or more items describing the specific changes. -->
- Keeps active rotation member at the start of the queue
- Puts a `(current)` marker on the active member for extra clarity
- Reverses param order for `RotationService` constructor
  - Consistency with `rotationBuilder` and the new order required the fewest changes

## Issue

<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->

N/A

## Additional Information

<!-- Any other information about this PR, such as a link to a Discord discussion. -->
Once merged, the triage and email rotation queues will need to be edited in Redis so we don't skip anyone on next rotation (since this changes it from `ping > rotate > report` to `rotate > ping > report`), so I'll get this done.

## Pull Request Requirements

<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->

- [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [x] If this PR addresses an open issue, it is linked in the `Issue` section
- [x] If this PR adds new features or functionality, I have added new tests
- [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
