### PR TITLE
Rotations: Tweak queue output formatting

### DIFF
--- a/bot-commands/rotations/email.js
+++ b/bot-commands/rotations/email.js
@@ -1,3 +1,3 @@
 const { rotationBuilder } = require('../../utils/rotation-builder');
 
-module.exports = rotationBuilder('email', 'emailRotationList');
+module.exports = rotationBuilder('Email', 'emailRotationList');

--- a/bot-commands/rotations/triage.js
+++ b/bot-commands/rotations/triage.js
@@ -1,3 +1,3 @@
 const { rotationBuilder } = require('../../utils/rotation-builder');
 
-module.exports = rotationBuilder('triage', 'maintainerTriageRotationList');
+module.exports = rotationBuilder('Triage', 'maintainerTriageRotationList');

--- a/services/rotations/rotation.service.js
+++ b/services/rotations/rotation.service.js
@@ -45,7 +45,7 @@ class RotationService {
       interaction.guild,
     );
     const formattedQueue = membersDisplayNames
-      .map((name, i) => `${name} ${i === 0 ? '(current) >' : '>'}`)
+      .map((name, i) => `${name} ${i === 0 ? '*(current)* >' : '>'}`)
       .join(' ');
 
     return formattedQueue
@@ -120,7 +120,7 @@ class RotationService {
   async #handleRotateQueue(interaction) {
     const memberToPing = await this.#rotateQueue(interaction);
 
-    let reply = `<@${memberToPing}> it's your turn for the ${this.rotationName} rotation.\n\n`;
+    let reply = `<@${memberToPing}> it's your turn for the ${this.rotationName.toLowerCase()} rotation.\n\n`;
     reply += await this.#getFormattedQueue(interaction);
 
     interaction.reply(reply.trim());

--- a/services/rotations/rotation.service.test.js
+++ b/services/rotations/rotation.service.test.js
@@ -9,7 +9,7 @@ jest.mock('../redis');
 
 describe('addition', () => {
   it('creates a rotation and reports the inital queue order', async () => {
-    const rotation = new RotationService('test', 'test');
+    const rotation = new RotationService('Test', 'test');
 
     const reply = jest.fn();
     const users = getUsers(2);
@@ -19,12 +19,12 @@ describe('addition', () => {
     await rotation.handleInteraction(interaction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@1234> <@5678> successfully added to the queue\n\ntest rotation queue order: Foo (current) > Baz >',
+      '<@1234> <@5678> successfully added to the queue\n\nTest rotation queue order: Foo *(current)* > Baz >',
     );
   });
 
   it('adds one person to the queue and reports the new queue order', async () => {
-    const rotation = new RotationService('test', 'test');
+    const rotation = new RotationService('Test', 'test');
 
     const creationUsers = getUsers(2);
     const server = initializeServer();
@@ -49,12 +49,12 @@ describe('addition', () => {
     await rotation.handleInteraction(additionInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@9101> successfully added to the queue\n\ntest rotation queue order: Foo (current) > Baz > Bang >',
+      '<@9101> successfully added to the queue\n\nTest rotation queue order: Foo *(current)* > Baz > Bang >',
     );
   });
 
   it('adds multiple people to the queue and reports the new queue order', async () => {
-    const rotation = new RotationService('test', 'test');
+    const rotation = new RotationService('Test', 'test');
 
     const creationUsers = getUsers(2);
     const server = initializeServer();
@@ -79,12 +79,12 @@ describe('addition', () => {
     await rotation.handleInteraction(additionInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@9101> <@1121> successfully added to the queue\n\ntest rotation queue order: Foo (current) > Baz > Bang > Bing >',
+      '<@9101> <@1121> successfully added to the queue\n\nTest rotation queue order: Foo *(current)* > Baz > Bang > Bing >',
     );
   });
 
   it('does not add people to the queue multiple times', async () => {
-    const rotation = new RotationService('test', 'test');
+    const rotation = new RotationService('Test', 'test');
 
     const creationUsers = getUsers(2);
     const server = initializeServer();
@@ -109,12 +109,12 @@ describe('addition', () => {
     await rotation.handleInteraction(additionInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      'Baz not added as they are already in the queue\n\n <@9101> <@1121> successfully added to the queue\n\ntest rotation queue order: Foo (current) > Baz > Bang > Bing >',
+      'Baz not added as they are already in the queue\n\n <@9101> <@1121> successfully added to the queue\n\nTest rotation queue order: Foo *(current)* > Baz > Bang > Bing >',
     );
   });
 
   it('addresses rejected users by nickname if they have one', async () => {
-    const rotation = new RotationService('test', 'test');
+    const rotation = new RotationService('Test', 'test');
 
     const creationUsers = getUsers(2);
     const additionUsers = getUsers(1);
@@ -142,12 +142,12 @@ describe('addition', () => {
     await rotation.handleInteraction(additionInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      'Bar not added as they are already in the queue\n\ntest rotation queue order: Bar (current) > Baz >',
+      'Bar not added as they are already in the queue\n\nTest rotation queue order: Bar *(current)* > Baz >',
     );
   });
 
   it('only replies once', async () => {
-    const rotation = new RotationService('test', 'test');
+    const rotation = new RotationService('Test', 'test');
 
     const creationUsers = getUsers(2);
     const server = initializeServer();
@@ -175,7 +175,7 @@ describe('addition', () => {
   });
 
   it('escapes markdown in usernames and nicknames', async () => {
-    const rotation = new RotationService('test', 'test');
+    const rotation = new RotationService('Test', 'test');
 
     const users = getUsers(2);
     users[0].nickname = 'Foo `test`';
@@ -189,14 +189,14 @@ describe('addition', () => {
     await rotation.handleInteraction(interaction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@1234> <@5678> successfully added to the queue\n\ntest rotation queue order: Foo \\`test\\` (current) > Baz \\*test\\* >',
+      '<@1234> <@5678> successfully added to the queue\n\nTest rotation queue order: Foo \\`test\\` *(current)* > Baz \\*test\\* >',
     );
   });
 });
 
 describe('removal', () => {
   it('removes one person from the start of the queue and reports the new queue order', async () => {
-    const rotation = new RotationService('test', 'test');
+    const rotation = new RotationService('Test', 'test');
 
     const creationUsers = getUsers(3);
     const server = initializeServer();
@@ -221,12 +221,12 @@ describe('removal', () => {
     await rotation.handleInteraction(removalInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@1234> removed from the queue\n\ntest rotation queue order: Baz (current) > Bang >',
+      '<@1234> removed from the queue\n\nTest rotation queue order: Baz *(current)* > Bang >',
     );
   });
 
   it('removes one person from the middle of the queue and reports the new queue order', async () => {
-    const rotation = new RotationService('test', 'test');
+    const rotation = new RotationService('Test', 'test');
 
     const creationUsers = getUsers(3);
     const server = initializeServer();
@@ -251,12 +251,12 @@ describe('removal', () => {
     await rotation.handleInteraction(removalInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@5678> removed from the queue\n\ntest rotation queue order: Foo (current) > Bang >',
+      '<@5678> removed from the queue\n\nTest rotation queue order: Foo *(current)* > Bang >',
     );
   });
 
   it('removes one person from the end of the queue and reports the new queue order', async () => {
-    const rotation = new RotationService('test', 'test');
+    const rotation = new RotationService('Test', 'test');
 
     const creationUsers = getUsers(3);
     const server = initializeServer();
@@ -281,12 +281,12 @@ describe('removal', () => {
     await rotation.handleInteraction(removalInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@9101> removed from the queue\n\ntest rotation queue order: Foo (current) > Baz >',
+      '<@9101> removed from the queue\n\nTest rotation queue order: Foo *(current)* > Baz >',
     );
   });
 
   it('only replies once', async () => {
-    const rotation = new RotationService('test', 'test');
+    const rotation = new RotationService('Test', 'test');
 
     const creationUsers = getUsers(3);
     const server = initializeServer();
@@ -314,7 +314,7 @@ describe('removal', () => {
   });
 
   it('escapes markdown in usernames and nicknames', async () => {
-    const rotation = new RotationService('test', 'test');
+    const rotation = new RotationService('Test', 'test');
 
     const users = getUsers(2);
     users[0].nickname = 'Foo `test`';
@@ -343,14 +343,14 @@ describe('removal', () => {
     await rotation.handleInteraction(removalInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@5678> removed from the queue\n\ntest rotation queue order: Foo \\`test\\` (current) >',
+      '<@5678> removed from the queue\n\nTest rotation queue order: Foo \\`test\\` *(current)* >',
     );
   });
 });
 
 describe('swapping', () => {
   it('swaps one person from the start of the queue with one from the end of the queue and reports the new queue order', async () => {
-    const rotation = new RotationService('test', 'test');
+    const rotation = new RotationService('Test', 'test');
 
     const creationUsers = getUsers(3);
     const server = initializeServer();
@@ -375,12 +375,12 @@ describe('swapping', () => {
     await rotation.handleInteraction(swappingInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@1234> <@9101> swapped position in the queue\n\ntest rotation queue order: Bang (current) > Baz > Foo >',
+      '<@1234> <@9101> swapped position in the queue\n\nTest rotation queue order: Bang *(current)* > Baz > Foo >',
     );
   });
 
   it('swaps one person from the start of the queue with one from the middle of the queue and reports the new queue order', async () => {
-    const rotation = new RotationService('test', 'test');
+    const rotation = new RotationService('Test', 'test');
 
     const creationUsers = getUsers(3);
     const server = initializeServer();
@@ -405,12 +405,12 @@ describe('swapping', () => {
     await rotation.handleInteraction(swappingInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@1234> <@5678> swapped position in the queue\n\ntest rotation queue order: Baz (current) > Foo > Bang >',
+      '<@1234> <@5678> swapped position in the queue\n\nTest rotation queue order: Baz *(current)* > Foo > Bang >',
     );
   });
 
   it('swaps one person from the middle of the queue with one from the end of the queue and reports the new queue order', async () => {
-    const rotation = new RotationService('test', 'test');
+    const rotation = new RotationService('Test', 'test');
 
     const creationUsers = getUsers(3);
     const server = initializeServer();
@@ -435,12 +435,12 @@ describe('swapping', () => {
     await rotation.handleInteraction(swappingInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@5678> <@9101> swapped position in the queue\n\ntest rotation queue order: Foo (current) > Bang > Baz >',
+      '<@5678> <@9101> swapped position in the queue\n\nTest rotation queue order: Foo *(current)* > Bang > Baz >',
     );
   });
 
   it('only replies once', async () => {
-    const rotation = new RotationService('test', 'test');
+    const rotation = new RotationService('Test', 'test');
 
     const creationUsers = getUsers(3);
     const server = initializeServer();
@@ -468,7 +468,7 @@ describe('swapping', () => {
   });
 
   it('escapes markdown in usernames and nicknames', async () => {
-    const rotation = new RotationService('test', 'test');
+    const rotation = new RotationService('Test', 'test');
 
     const users = getUsers(2);
     users[0].nickname = 'Foo `test`';
@@ -491,14 +491,14 @@ describe('swapping', () => {
     await rotation.handleInteraction(swapInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@1234> <@5678> swapped position in the queue\n\ntest rotation queue order: Baz \\*test\\* (current) > Foo \\`test\\` >',
+      '<@1234> <@5678> swapped position in the queue\n\nTest rotation queue order: Baz \\*test\\* *(current)* > Foo \\`test\\` >',
     );
   });
 });
 
 describe('reading', () => {
   it('reports the queue order', async () => {
-    const rotation = new RotationService('test', 'test');
+    const rotation = new RotationService('Test', 'test');
 
     const creationUsers = getUsers(3);
     const server = initializeServer();
@@ -517,12 +517,12 @@ describe('reading', () => {
     await rotation.handleInteraction(readInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      'test rotation queue order: Foo (current) > Baz > Bang >',
+      'Test rotation queue order: Foo *(current)* > Baz > Bang >',
     );
   });
 
   it('only replies once', async () => {
-    const rotation = new RotationService('test', 'test');
+    const rotation = new RotationService('Test', 'test');
 
     const creationUsers = getUsers(3);
     const server = initializeServer();
@@ -544,7 +544,7 @@ describe('reading', () => {
   });
 
   it('escapes markdown in usernames and nicknames', async () => {
-    const rotation = new RotationService('test', 'test');
+    const rotation = new RotationService('Test', 'test');
 
     const users = getUsers(2);
     users[0].nickname = 'Foo `test`';
@@ -567,14 +567,14 @@ describe('reading', () => {
     await rotation.handleInteraction(readInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      'test rotation queue order: Foo \\`test\\` (current) > Baz \\*test\\* >',
+      'Test rotation queue order: Foo \\`test\\` *(current)* > Baz \\*test\\* >',
     );
   });
 });
 
 describe('rotation', () => {
   it('rotates the queue, pings the new first user in the rotation then reports the new queue order', async () => {
-    const rotation = new RotationService('test', 'test');
+    const rotation = new RotationService('Test', 'test');
 
     const creationUsers = getUsers(3);
     const server = initializeServer();
@@ -593,12 +593,12 @@ describe('rotation', () => {
     await rotation.handleInteraction(rotationInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      "<@5678> it's your turn for the test rotation.\n\ntest rotation queue order: Baz (current) > Bang > Foo >",
+      "<@5678> it's your turn for the test rotation.\n\nTest rotation queue order: Baz *(current)* > Bang > Foo >",
     );
   });
 
   it('only replies once', async () => {
-    const rotation = new RotationService('test', 'test');
+    const rotation = new RotationService('Test', 'test');
 
     const creationUsers = getUsers(3);
     const server = initializeServer();
@@ -620,7 +620,7 @@ describe('rotation', () => {
   });
 
   it('escapes markdown in usernames and nicknames', async () => {
-    const rotation = new RotationService('test', 'test');
+    const rotation = new RotationService('Test', 'test');
 
     const users = getUsers(2);
     users[0].nickname = 'Foo `test`';
@@ -643,7 +643,7 @@ describe('rotation', () => {
     await rotation.handleInteraction(rotateInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      "<@5678> it's your turn for the test rotation.\n\ntest rotation queue order: Baz \\*test\\* (current) > Foo \\`test\\` >",
+      "<@5678> it's your turn for the test rotation.\n\nTest rotation queue order: Baz \\*test\\* *(current)* > Foo \\`test\\` >",
     );
   });
 });


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because

<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
112.9% self-nit but:
- I don't like how the queue output doesn't open the sentence with a capital letter
- `(current)` could be made more distinct from username text. Example:
  1. var(--cody) (current)
  2. var(--cody) *(current)*

## This PR

<!-- A bullet point list of one or more items describing the specific changes. -->
- Capitalises rotation names
- Italicises `(current)` marker in queue

## Issue

<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->

N/A

## Pull Request Requirements

<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->

- [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [x] If this PR addresses an open issue, it is linked in the `Issue` section
- [x] If this PR adds new features or functionality, I have added new tests
- [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
