### PR TITLE
Rotation current formatting

### DIFF
--- a/services/rotations/rotation.service.js
+++ b/services/rotations/rotation.service.js
@@ -48,8 +48,10 @@ class RotationService {
       .map((name, i) => `${name} ${i === 0 ? '*(current)* >' : '>'}`)
       .join(' ');
 
+    const capitalizedRotationName =
+      this.rotationName[0].toUpperCase() + this.rotationName.slice(1);
     return formattedQueue
-      ? `${this.rotationName} rotation queue order: ${formattedQueue}`
+      ? `${capitalizedRotationName} rotation queue order: ${formattedQueue}`
       : 'No members';
   }
 

--- a/services/rotations/rotation.service.js
+++ b/services/rotations/rotation.service.js
@@ -45,7 +45,7 @@ class RotationService {
       interaction.guild,
     );
     const formattedQueue = membersDisplayNames
-      .map((name, i) => `${name} ${i === 0 ? '(current) >' : '>'}`)
+      .map((name, i) => `${name} ${i === 0 ? '*(current)* >' : '>'}`)
       .join(' ');
 
     return formattedQueue

--- a/services/rotations/rotation.service.test.js
+++ b/services/rotations/rotation.service.test.js
@@ -19,7 +19,7 @@ describe('addition', () => {
     await rotation.handleInteraction(interaction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@1234> <@5678> successfully added to the queue\n\ntest rotation queue order: Foo *(current)* > Baz >',
+      '<@1234> <@5678> successfully added to the queue\n\nTest rotation queue order: Foo *(current)* > Baz >',
     );
   });
 
@@ -49,7 +49,7 @@ describe('addition', () => {
     await rotation.handleInteraction(additionInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@9101> successfully added to the queue\n\ntest rotation queue order: Foo *(current)* > Baz > Bang >',
+      '<@9101> successfully added to the queue\n\nTest rotation queue order: Foo *(current)* > Baz > Bang >',
     );
   });
 
@@ -79,7 +79,7 @@ describe('addition', () => {
     await rotation.handleInteraction(additionInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@9101> <@1121> successfully added to the queue\n\ntest rotation queue order: Foo *(current)* > Baz > Bang > Bing >',
+      '<@9101> <@1121> successfully added to the queue\n\nTest rotation queue order: Foo *(current)* > Baz > Bang > Bing >',
     );
   });
 
@@ -109,7 +109,7 @@ describe('addition', () => {
     await rotation.handleInteraction(additionInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      'Baz not added as they are already in the queue\n\n <@9101> <@1121> successfully added to the queue\n\ntest rotation queue order: Foo *(current)* > Baz > Bang > Bing >',
+      'Baz not added as they are already in the queue\n\n <@9101> <@1121> successfully added to the queue\n\nTest rotation queue order: Foo *(current)* > Baz > Bang > Bing >',
     );
   });
 
@@ -142,7 +142,7 @@ describe('addition', () => {
     await rotation.handleInteraction(additionInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      'Bar not added as they are already in the queue\n\ntest rotation queue order: Bar *(current)* > Baz >',
+      'Bar not added as they are already in the queue\n\nTest rotation queue order: Bar *(current)* > Baz >',
     );
   });
 
@@ -189,7 +189,7 @@ describe('addition', () => {
     await rotation.handleInteraction(interaction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@1234> <@5678> successfully added to the queue\n\ntest rotation queue order: Foo \\`test\\` *(current)* > Baz \\*test\\* >',
+      '<@1234> <@5678> successfully added to the queue\n\nTest rotation queue order: Foo \\`test\\` *(current)* > Baz \\*test\\* >',
     );
   });
 });
@@ -221,7 +221,7 @@ describe('removal', () => {
     await rotation.handleInteraction(removalInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@1234> removed from the queue\n\ntest rotation queue order: Baz *(current)* > Bang >',
+      '<@1234> removed from the queue\n\nTest rotation queue order: Baz *(current)* > Bang >',
     );
   });
 
@@ -251,7 +251,7 @@ describe('removal', () => {
     await rotation.handleInteraction(removalInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@5678> removed from the queue\n\ntest rotation queue order: Foo *(current)* > Bang >',
+      '<@5678> removed from the queue\n\nTest rotation queue order: Foo *(current)* > Bang >',
     );
   });
 
@@ -281,7 +281,7 @@ describe('removal', () => {
     await rotation.handleInteraction(removalInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@9101> removed from the queue\n\ntest rotation queue order: Foo *(current)* > Baz >',
+      '<@9101> removed from the queue\n\nTest rotation queue order: Foo *(current)* > Baz >',
     );
   });
 
@@ -343,7 +343,7 @@ describe('removal', () => {
     await rotation.handleInteraction(removalInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@5678> removed from the queue\n\ntest rotation queue order: Foo \\`test\\` *(current)* >',
+      '<@5678> removed from the queue\n\nTest rotation queue order: Foo \\`test\\` *(current)* >',
     );
   });
 });
@@ -375,7 +375,7 @@ describe('swapping', () => {
     await rotation.handleInteraction(swappingInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@1234> <@9101> swapped position in the queue\n\ntest rotation queue order: Bang *(current)* > Baz > Foo >',
+      '<@1234> <@9101> swapped position in the queue\n\nTest rotation queue order: Bang *(current)* > Baz > Foo >',
     );
   });
 
@@ -405,7 +405,7 @@ describe('swapping', () => {
     await rotation.handleInteraction(swappingInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@1234> <@5678> swapped position in the queue\n\ntest rotation queue order: Baz *(current)* > Foo > Bang >',
+      '<@1234> <@5678> swapped position in the queue\n\nTest rotation queue order: Baz *(current)* > Foo > Bang >',
     );
   });
 
@@ -435,7 +435,7 @@ describe('swapping', () => {
     await rotation.handleInteraction(swappingInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@5678> <@9101> swapped position in the queue\n\ntest rotation queue order: Foo *(current)* > Bang > Baz >',
+      '<@5678> <@9101> swapped position in the queue\n\nTest rotation queue order: Foo *(current)* > Bang > Baz >',
     );
   });
 
@@ -491,7 +491,7 @@ describe('swapping', () => {
     await rotation.handleInteraction(swapInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@1234> <@5678> swapped position in the queue\n\ntest rotation queue order: Baz \\*test\\* *(current)* > Foo \\`test\\` >',
+      '<@1234> <@5678> swapped position in the queue\n\nTest rotation queue order: Baz \\*test\\* *(current)* > Foo \\`test\\` >',
     );
   });
 });
@@ -517,7 +517,7 @@ describe('reading', () => {
     await rotation.handleInteraction(readInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      'test rotation queue order: Foo *(current)* > Baz > Bang >',
+      'Test rotation queue order: Foo *(current)* > Baz > Bang >',
     );
   });
 
@@ -567,7 +567,7 @@ describe('reading', () => {
     await rotation.handleInteraction(readInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      'test rotation queue order: Foo \\`test\\` *(current)* > Baz \\*test\\* >',
+      'Test rotation queue order: Foo \\`test\\` *(current)* > Baz \\*test\\* >',
     );
   });
 });
@@ -593,7 +593,7 @@ describe('rotation', () => {
     await rotation.handleInteraction(rotationInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      "<@5678> it's your turn for the test rotation.\n\ntest rotation queue order: Baz *(current)* > Bang > Foo >",
+      "<@5678> it's your turn for the test rotation.\n\nTest rotation queue order: Baz *(current)* > Bang > Foo >",
     );
   });
 
@@ -643,7 +643,7 @@ describe('rotation', () => {
     await rotation.handleInteraction(rotateInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      "<@5678> it's your turn for the test rotation.\n\ntest rotation queue order: Baz \\*test\\* *(current)* > Foo \\`test\\` >",
+      "<@5678> it's your turn for the test rotation.\n\nTest rotation queue order: Baz \\*test\\* *(current)* > Foo \\`test\\` >",
     );
   });
 });

--- a/services/rotations/rotation.service.test.js
+++ b/services/rotations/rotation.service.test.js
@@ -19,7 +19,7 @@ describe('addition', () => {
     await rotation.handleInteraction(interaction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@1234> <@5678> successfully added to the queue\n\ntest rotation queue order: Foo (current) > Baz >',
+      '<@1234> <@5678> successfully added to the queue\n\ntest rotation queue order: Foo *(current)* > Baz >',
     );
   });
 
@@ -49,7 +49,7 @@ describe('addition', () => {
     await rotation.handleInteraction(additionInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@9101> successfully added to the queue\n\ntest rotation queue order: Foo (current) > Baz > Bang >',
+      '<@9101> successfully added to the queue\n\ntest rotation queue order: Foo *(current)* > Baz > Bang >',
     );
   });
 
@@ -79,7 +79,7 @@ describe('addition', () => {
     await rotation.handleInteraction(additionInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@9101> <@1121> successfully added to the queue\n\ntest rotation queue order: Foo (current) > Baz > Bang > Bing >',
+      '<@9101> <@1121> successfully added to the queue\n\ntest rotation queue order: Foo *(current)* > Baz > Bang > Bing >',
     );
   });
 
@@ -109,7 +109,7 @@ describe('addition', () => {
     await rotation.handleInteraction(additionInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      'Baz not added as they are already in the queue\n\n <@9101> <@1121> successfully added to the queue\n\ntest rotation queue order: Foo (current) > Baz > Bang > Bing >',
+      'Baz not added as they are already in the queue\n\n <@9101> <@1121> successfully added to the queue\n\ntest rotation queue order: Foo *(current)* > Baz > Bang > Bing >',
     );
   });
 
@@ -142,7 +142,7 @@ describe('addition', () => {
     await rotation.handleInteraction(additionInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      'Bar not added as they are already in the queue\n\ntest rotation queue order: Bar (current) > Baz >',
+      'Bar not added as they are already in the queue\n\ntest rotation queue order: Bar *(current)* > Baz >',
     );
   });
 
@@ -189,7 +189,7 @@ describe('addition', () => {
     await rotation.handleInteraction(interaction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@1234> <@5678> successfully added to the queue\n\ntest rotation queue order: Foo \\`test\\` (current) > Baz \\*test\\* >',
+      '<@1234> <@5678> successfully added to the queue\n\ntest rotation queue order: Foo \\`test\\` *(current)* > Baz \\*test\\* >',
     );
   });
 });
@@ -221,7 +221,7 @@ describe('removal', () => {
     await rotation.handleInteraction(removalInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@1234> removed from the queue\n\ntest rotation queue order: Baz (current) > Bang >',
+      '<@1234> removed from the queue\n\ntest rotation queue order: Baz *(current)* > Bang >',
     );
   });
 
@@ -251,7 +251,7 @@ describe('removal', () => {
     await rotation.handleInteraction(removalInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@5678> removed from the queue\n\ntest rotation queue order: Foo (current) > Bang >',
+      '<@5678> removed from the queue\n\ntest rotation queue order: Foo *(current)* > Bang >',
     );
   });
 
@@ -281,7 +281,7 @@ describe('removal', () => {
     await rotation.handleInteraction(removalInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@9101> removed from the queue\n\ntest rotation queue order: Foo (current) > Baz >',
+      '<@9101> removed from the queue\n\ntest rotation queue order: Foo *(current)* > Baz >',
     );
   });
 
@@ -343,7 +343,7 @@ describe('removal', () => {
     await rotation.handleInteraction(removalInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@5678> removed from the queue\n\ntest rotation queue order: Foo \\`test\\` (current) >',
+      '<@5678> removed from the queue\n\ntest rotation queue order: Foo \\`test\\` *(current)* >',
     );
   });
 });
@@ -375,7 +375,7 @@ describe('swapping', () => {
     await rotation.handleInteraction(swappingInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@1234> <@9101> swapped position in the queue\n\ntest rotation queue order: Bang (current) > Baz > Foo >',
+      '<@1234> <@9101> swapped position in the queue\n\ntest rotation queue order: Bang *(current)* > Baz > Foo >',
     );
   });
 
@@ -405,7 +405,7 @@ describe('swapping', () => {
     await rotation.handleInteraction(swappingInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@1234> <@5678> swapped position in the queue\n\ntest rotation queue order: Baz (current) > Foo > Bang >',
+      '<@1234> <@5678> swapped position in the queue\n\ntest rotation queue order: Baz *(current)* > Foo > Bang >',
     );
   });
 
@@ -435,7 +435,7 @@ describe('swapping', () => {
     await rotation.handleInteraction(swappingInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@5678> <@9101> swapped position in the queue\n\ntest rotation queue order: Foo (current) > Bang > Baz >',
+      '<@5678> <@9101> swapped position in the queue\n\ntest rotation queue order: Foo *(current)* > Bang > Baz >',
     );
   });
 
@@ -491,7 +491,7 @@ describe('swapping', () => {
     await rotation.handleInteraction(swapInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      '<@1234> <@5678> swapped position in the queue\n\ntest rotation queue order: Baz \\*test\\* (current) > Foo \\`test\\` >',
+      '<@1234> <@5678> swapped position in the queue\n\ntest rotation queue order: Baz \\*test\\* *(current)* > Foo \\`test\\` >',
     );
   });
 });
@@ -517,7 +517,7 @@ describe('reading', () => {
     await rotation.handleInteraction(readInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      'test rotation queue order: Foo (current) > Baz > Bang >',
+      'test rotation queue order: Foo *(current)* > Baz > Bang >',
     );
   });
 
@@ -567,7 +567,7 @@ describe('reading', () => {
     await rotation.handleInteraction(readInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      'test rotation queue order: Foo \\`test\\` (current) > Baz \\*test\\* >',
+      'test rotation queue order: Foo \\`test\\` *(current)* > Baz \\*test\\* >',
     );
   });
 });
@@ -593,7 +593,7 @@ describe('rotation', () => {
     await rotation.handleInteraction(rotationInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      "<@5678> it's your turn for the test rotation.\n\ntest rotation queue order: Baz (current) > Bang > Foo >",
+      "<@5678> it's your turn for the test rotation.\n\ntest rotation queue order: Baz *(current)* > Bang > Foo >",
     );
   });
 
@@ -643,7 +643,7 @@ describe('rotation', () => {
     await rotation.handleInteraction(rotateInteraction);
 
     expect(reply).toHaveBeenCalledWith(
-      "<@5678> it's your turn for the test rotation.\n\ntest rotation queue order: Baz \\*test\\* (current) > Foo \\`test\\` >",
+      "<@5678> it's your turn for the test rotation.\n\ntest rotation queue order: Baz \\*test\\* *(current)* > Foo \\`test\\` >",
     );
   });
 });


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because

<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Because I'm an idiot and somehow didn't properly test #828 in dev (it crashes - slash command names must be lowercase).

## This PR

<!-- A bullet point list of one or more items describing the specific changes. -->
- Capitalises rotation names
- Italicises (current) marker in queue

## Issue

<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->

N/A

## Additional information

Proof it does work in dev this time
<img width="610" height="258" alt="image" src="https://github.com/user-attachments/assets/70ead4b7-9ef3-4fa0-858c-3d8f1b5110c5" />


## Pull Request Requirements

<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->

- [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [x] If this PR addresses an open issue, it is linked in the `Issue` section
- [x] If this PR adds new features or functionality, I have added new tests
- [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
