### PR TITLE
Spam kicker: Kick on more than one attachment

### DIFF
--- a/events/message-create.js
+++ b/events/message-create.js
@@ -62,8 +62,8 @@ module.exports = {
 
     const isAdminMessage = isAdmin(message.member);
 
-    // Kick people who posts more than 4 attachments
-    if (!isAdminMessage && message.attachments.size >= 4) {
+    // Kick people who posts more than 1 attachment
+    if (!isAdminMessage && message.attachments.size > 1) {
       try {
         // Deleting a message that has been already deleted by other bots will throw an error, we ignore it in that case
         await message.delete();

--- a/events/message-create.test.js
+++ b/events/message-create.test.js
@@ -32,7 +32,7 @@ describe('Spam detection', () => {
     return new Message({
       author: member.user,
       member,
-      attachments: { size: 4 },
+      attachments: { size: 2 },
     });
   }
 

--- a/services/spam-kick/__snapshots__/spammer-kick-service.test.js.snap
+++ b/services/spam-kick/__snapshots__/spammer-kick-service.test.js.snap
@@ -20,7 +20,7 @@ exports[`Kicking spammer Kicked spammer info is logged in moderation channel 1`]
         {
           "inline": true,
           "name": "Reason",
-          "value": "User has been kicked for posting more than 4 attachments in a single message.",
+          "value": "User has been kicked for posting more than 1 attachment in a single message.",
         },
       ],
       "footer": {
@@ -60,7 +60,7 @@ exports[`Warning spammer Warning is logged in moderation channel 1`] = `
         {
           "inline": true,
           "name": "Reason",
-          "value": "User has been warned for posting more than 4 attachments in a single message. Next offense will result in a kick.",
+          "value": "User has been warned for posting more than 1 attachment in a single message. Next offense will result in a kick.",
         },
       ],
       "footer": {

--- a/services/spam-kick/spammer-kick-service.js
+++ b/services/spam-kick/spammer-kick-service.js
@@ -17,7 +17,7 @@ class SpamKickingService {
         action: 'Kick',
         color: 15747399,
         reason:
-          'User has been kicked for posting more than 4 attachments in a single message.',
+          'User has been kicked for posting more than 1 attachment in a single message.',
       });
       await member.kick(
         'Attachments spam, account flagged for being compromised',
@@ -41,7 +41,7 @@ class SpamKickingService {
         action: 'Warning',
         color: 16776960,
         reason:
-          'User has been warned for posting more than 4 attachments in a single message. Next offense will result in a kick.',
+          'User has been warned for posting more than 1 attachment in a single message. Next offense will result in a kick.',
       });
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because

<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->

Spammers are now posting their scams in 2 images instead of 1

## This PR

<!-- A bullet point list of one or more items describing the specific changes. -->

Drops the check from more than 3 attachments to more than 1

## Issue

<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->

Closes #XXXXX

## Additional Information

<!-- Any other information about this PR, such as a link to a Discord discussion. -->

## Pull Request Requirements

<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->

- [X] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
- [X] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
- [X] The `Because` section summarizes the reason for this PR
- [X] The `This PR` section has a bullet point list describing the changes in this PR
- [X] If this PR addresses an open issue, it is linked in the `Issue` section
- [X] If this PR adds new features or functionality, I have added new tests
- [X] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
