### PR TITLE
SpamKickingService: Use single source of truth for attachment limit

### DIFF
--- a/events/message-create.js
+++ b/events/message-create.js
@@ -62,8 +62,11 @@ module.exports = {
 
     const isAdminMessage = isAdmin(message.member);
 
-    // Kick people who posts more than 1 attachment
-    if (!isAdminMessage && message.attachments.size > 1) {
+    // Warn or kick people who posts multiple attachments
+    if (
+      !isAdminMessage &&
+      message.attachments.size > SpamKickingService.ATTACHMENT_LIMIT
+    ) {
       try {
         // Deleting a message that has been already deleted by other bots will throw an error, we ignore it in that case
         await message.delete();

--- a/events/message-create.test.js
+++ b/events/message-create.test.js
@@ -1,9 +1,6 @@
 const { Guild, GuildMember, Message, Role } = require('../utils/mocks/discord');
 
-jest.mock('../services/spam-kick/spammer-kick-service', () => ({
-  kick: jest.fn(),
-  warn: jest.fn(),
-}));
+jest.mock('../services/spam-kick/spammer-kick-service');
 
 describe('Spam detection', () => {
   let execute;

--- a/services/spam-kick/__snapshots__/spammer-kick-service.test.js.snap
+++ b/services/spam-kick/__snapshots__/spammer-kick-service.test.js.snap
@@ -20,7 +20,7 @@ exports[`Kicking spammer Kicked spammer info is logged in moderation channel 1`]
         {
           "inline": true,
           "name": "Reason",
-          "value": "User has been kicked for posting more than 1 attachment in a single message.",
+          "value": "User has been kicked for posting 2 or more attachments in a single message.",
         },
       ],
       "footer": {
@@ -60,7 +60,7 @@ exports[`Warning spammer Warning is logged in moderation channel 1`] = `
         {
           "inline": true,
           "name": "Reason",
-          "value": "User has been warned for posting more than 1 attachment in a single message. Next offense will result in a kick.",
+          "value": "User has been warned for posting 2 or more attachments in a single message. Next offense will result in a kick.",
         },
       ],
       "footer": {

--- a/services/spam-kick/spammer-kick-service.js
+++ b/services/spam-kick/spammer-kick-service.js
@@ -2,6 +2,8 @@ const config = require('../../config');
 const { isAdmin } = require('../../utils/is-admin');
 
 class SpamKickingService {
+  static ATTACHMENT_LIMIT = 1;
+
   static async kick(member) {
     try {
       if (isAdmin(member)) {
@@ -16,8 +18,7 @@ class SpamKickingService {
       await SpamKickingService.#logAction(member, {
         action: 'Kick',
         color: 15747399,
-        reason:
-          'User has been kicked for posting more than 1 attachment in a single message.',
+        reason: `User has been kicked for posting ${SpamKickingService.ATTACHMENT_LIMIT + 1} or more attachments in a single message.`,
       });
       await member.kick(
         'Attachments spam, account flagged for being compromised',
@@ -40,8 +41,7 @@ class SpamKickingService {
       await SpamKickingService.#logAction(member, {
         action: 'Warning',
         color: 16776960,
-        reason:
-          'User has been warned for posting more than 1 attachment in a single message. Next offense will result in a kick.',
+        reason: `User has been warned for posting ${SpamKickingService.ATTACHMENT_LIMIT + 1} or more attachments in a single message. Next offense will result in a kick.`,
       });
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because

Currently, if the attachment limit needs changing, it needs multiple magic numbers to be changed (e.g. https://github.com/TheOdinProject/odin-bot-v2/commit/5f8492519d35e1c06797c544b710c2ff678b0de3). This should come from a single source of truth.
Rephrased to `"ATTACHMENT_LIMIT + 1 or more attachments"` so we don't have to deal with pluralisation shenanigans.

The Jest automock of `SpamKickingService` didn't need a manual return object, since this hardcodes the entire implementation and makes `ATTACHMENT_LIMIT` undefined. Automocking a class automatically mocks static methods with `jest.fn()` anyway (can test by logging `SpamKickingService` and you'll see the static methods are replaced accordingly.

## This PR

<!-- A bullet point list of one or more items describing the specific changes. -->
- Moves attachment limit for SpamKickingService to a single source of truth
- Updates test snapshots
- Fixes redundancies in SpamKickingService mock

## Issue

<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->

N/A

## Additional Information

<!-- Any other information about this PR, such as a link to a Discord discussion. -->

## Pull Request Requirements

<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->

- [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [x] If this PR addresses an open issue, it is linked in the `Issue` section
- [x] If this PR adds new features or functionality, I have added new tests
- [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
