### PR TITLE
ESLint: Fix not recognising modern JS syntax

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,7 @@ module.exports = defineConfig([
       reportUnusedDisableDirectives: 'warn',
     },
     languageOptions: {
+      ecmaVersion: 'latest',
       sourceType: 'commonjs',
       globals: { ...globals.node, ...globals.jest },
     },


### PR DESCRIPTION


<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because

No longer using ESLint babel parser
Not sure why we still need to explicitly define `'latest'` for the ecmaVersion. Docs say it's the default and don't say anything about it changing if `sourceType` is set to `'commonjs'`.

:shrug:
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->

## This PR

<!-- A bullet point list of one or more items describing the specific changes. -->
- Ensures ESLint parses with latest ecmaVersion

