### PR TITLE
PendingMigrationsError: Change to more generic DatabaseError

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const { Client, GatewayIntentBits, Partials } = require('discord.js');
 const { token, channels } = require('./config');
 const MissingEnvVarError = require('./utils/errors/missing-env-var');
-const PendingMigrationsError = require('./utils/errors/database');
+const DatabaseError = require('./utils/errors/database');
 const DuplicateIdsError = require('./utils/errors/duplicate-ids');
 
 const missingMandatoryEnvKeys = MissingEnvVarError.getMissingMandatoryKeys();
@@ -9,8 +9,9 @@ if (missingMandatoryEnvKeys.length) {
   throw new MissingEnvVarError(missingMandatoryEnvKeys);
 }
 
-if (PendingMigrationsError.hasPendingMigrations()) {
-  throw new PendingMigrationsError();
+const databaseErrorCode = DatabaseError.checkMigrations();
+if (databaseErrorCode) {
+  throw new DatabaseError(databaseErrorCode);
 }
 
 const duplicateKeys = DuplicateIdsError.getDuplicateIds(channels);

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const { Client, GatewayIntentBits, Partials } = require('discord.js');
 const { token, channels } = require('./config');
 const MissingEnvVarError = require('./utils/errors/missing-env-var');
-const PendingMigrationsError = require('./utils/errors/pending-migrations');
+const PendingMigrationsError = require('./utils/errors/database');
 const DuplicateIdsError = require('./utils/errors/duplicate-ids');
 
 const missingMandatoryEnvKeys = MissingEnvVarError.getMissingMandatoryKeys();

--- a/test/global-setup.js
+++ b/test/global-setup.js
@@ -1,11 +1,23 @@
 require('../utils/load-env').load();
 const MissingEnvVarError = require('../utils/errors/missing-env-var');
+const DatabaseError = require('../utils/errors/database');
 const { execSync } = require('node:child_process');
+
+const PENDING_MIGRATIONS_ERROR_CODE = 1;
 
 module.exports = () => {
   const missingMandatoryEnvKeys = MissingEnvVarError.getMissingMandatoryKeys();
   if (missingMandatoryEnvKeys.length) {
     throw new MissingEnvVarError(missingMandatoryEnvKeys);
+  }
+
+  const databaseErrorCode = DatabaseError.checkMigrations();
+  // no need to throw if pending migrations, automatically applied after this
+  if (
+    databaseErrorCode &&
+    databaseErrorCode !== PENDING_MIGRATIONS_ERROR_CODE
+  ) {
+    throw new DatabaseError(databaseErrorCode);
   }
 
   // Must run DB migrations in global setup and not in package.json script

--- a/test/global-setup.js
+++ b/test/global-setup.js
@@ -3,21 +3,16 @@ const MissingEnvVarError = require('../utils/errors/missing-env-var');
 const DatabaseError = require('../utils/errors/database');
 const { execSync } = require('node:child_process');
 
-const PENDING_MIGRATIONS_ERROR_CODE = 1;
-
 module.exports = () => {
   const missingMandatoryEnvKeys = MissingEnvVarError.getMissingMandatoryKeys();
   if (missingMandatoryEnvKeys.length) {
     throw new MissingEnvVarError(missingMandatoryEnvKeys);
   }
 
-  const databaseErrorCode = DatabaseError.checkMigrations();
+  const errorCode = DatabaseError.checkMigrations();
   // no need to throw if pending migrations, automatically applied after this
-  if (
-    databaseErrorCode &&
-    databaseErrorCode !== PENDING_MIGRATIONS_ERROR_CODE
-  ) {
-    throw new DatabaseError(databaseErrorCode);
+  if (errorCode && errorCode !== DatabaseError.codes.pendingMigrations) {
+    throw new DatabaseError(errorCode);
   }
 
   // Must run DB migrations in global setup and not in package.json script

--- a/utils/errors/database.js
+++ b/utils/errors/database.js
@@ -1,19 +1,39 @@
 const { execSync } = require('node:child_process');
 
 class DatabaseError extends Error {
-  constructor() {
-    super(
+  static #databaseEnvVar =
+    process.env.NODE_ENV === 'test' ? 'TEST_DATABASE_URL' : 'DATABASE_URL';
+  static #messages = new Map()
+    .set(
+      1,
       'There are migrations pending. Please run `npm run migrate` to apply these migrations.',
+    )
+    .set(
+      2,
+      `
+Unable to connect to the database.
+Is the ${DatabaseError.#databaseEnvVar} connection string correct?
+Have you made sure to enable and start the PostgreSQL service on your system?
+      `,
     );
+
+  constructor(errorCode) {
+    const message =
+      DatabaseError.#messages.get(errorCode) ??
+      `Unknown error code ${errorCode} when trying to connect to the database. Please file a bug report: https://github.com/TheOdinProject/odin-bot-v2/issues/new?template=bug_report.yaml`;
+
+    super(message);
     this.name = 'DatabaseError';
   }
 
-  static hasPendingMigrations() {
+  static checkMigrations() {
     try {
-      execSync('npm run migrate:status');
-      return false;
-    } catch {
-      return true;
+      execSync(
+        `npx dbmate --env=${DatabaseError.#databaseEnvVar} status --exit-code`,
+      );
+      return 0;
+    } catch (error) {
+      return error.status;
     }
   }
 }

--- a/utils/errors/database.js
+++ b/utils/errors/database.js
@@ -1,11 +1,11 @@
 const { execSync } = require('node:child_process');
 
-class PendingMigrationsError extends Error {
+class DatabaseError extends Error {
   constructor() {
     super(
       'There are migrations pending. Please run `npm run migrate` to apply these migrations.',
     );
-    this.name = 'PendingMigrationsError';
+    this.name = 'DatabaseError';
   }
 
   static hasPendingMigrations() {
@@ -18,4 +18,4 @@ class PendingMigrationsError extends Error {
   }
 }
 
-module.exports = PendingMigrationsError;
+module.exports = DatabaseError;

--- a/utils/errors/database.js
+++ b/utils/errors/database.js
@@ -3,13 +3,17 @@ const { execSync } = require('node:child_process');
 class DatabaseError extends Error {
   static #databaseEnvVar =
     process.env.NODE_ENV === 'test' ? 'TEST_DATABASE_URL' : 'DATABASE_URL';
+  static #codes = {
+    pendingMigrations: 1,
+    connectionError: 2,
+  };
   static #messages = new Map()
     .set(
-      1,
+      DatabaseError.#codes.pendingMigrations,
       'There are migrations pending. Please run `npm run migrate` to apply these migrations.',
     )
     .set(
-      2,
+      DatabaseError.#codes.connectionError,
       `
 Unable to connect to the database.
 Is the ${DatabaseError.#databaseEnvVar} connection string correct?
@@ -24,6 +28,10 @@ Have you made sure to enable and start the PostgreSQL service on your system?
 
     super(message);
     this.name = 'DatabaseError';
+  }
+
+  static get codes() {
+    return DatabaseError.#codes;
   }
 
   static checkMigrations() {


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because

<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Currently, one of the startup checks is whether there are pending migrations to apply. This isn't the only database-related startup error though. Right now, if the connection string isn't accurate or `postgresql.service` isn't running, it still reports the pending migrations error.
`dbmate status --exit-code` returns `1` when connected but pending migrations, and `2` for db connection issues.

I do not know if `postgresql.service` and `systemctl` is different for different distros, or how it's handled on macOS (macOS guide doesn't mention anything about it), so I've left that error message more general for people to google if they run into it.

## This PR

<!-- A bullet point list of one or more items describing the specific changes. -->
- Renames PendingMigrationsError to the more generic DatabaseError
- Ensures a relevant error message depending on the actual cause (both for the bot and for tests)

## Issue

<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->

Closes #XXXXX

## Additional Information

<!-- Any other information about this PR, such as a link to a Discord discussion. -->

## Pull Request Requirements

<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->

- [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [x] If this PR addresses an open issue, it is linked in the `Issue` section
- [x] If this PR adds new features or functionality, I have added new tests
- [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
