### PR TITLE
Jest: Fix DB pool/migration issues in watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "prepare": "husky",
     "start": "node index.js",
     "dev": "nodemon --watch . --watch .env index.js",
-    "test": "dbmate --env=TEST_DATABASE_URL --no-dump-schema up && NODE_OPTIONS=--experimental-vm-modules jest --runInBand",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --runInBand",
     "migrate": "dbmate up",
     "migrate:only": "dbmate --no-dump-schema up",
     "migrate:rollback": "dbmate rollback",

--- a/test/global-setup.js
+++ b/test/global-setup.js
@@ -1,9 +1,15 @@
 require('dotenv').config({ quiet: true });
 const MissingEnvVarError = require('../utils/errors/missing-env-var');
+const { execSync } = require('node:child_process');
 
 module.exports = () => {
   const missingMandatoryEnvKeys = MissingEnvVarError.getMissingMandatoryKeys();
   if (missingMandatoryEnvKeys.length) {
     throw new MissingEnvVarError(missingMandatoryEnvKeys);
   }
+
+  // Must run DB migrations in global setup and not in package.json script
+  // to ensure if watch mode is used, the migrations apply on each test rerun,
+  // not just the first run (global teardown resets the DB).
+  execSync('npx dbmate --env=TEST_DATABASE_URL --no-dump-schema up');
 };

--- a/test/global-teardown.js
+++ b/test/global-teardown.js
@@ -1,10 +1,17 @@
 const db = require('../db');
 
-module.exports = async () => {
-  // ensure no test run can interfere with the setup of a future test run
+module.exports = async ({ watch, watchAll }) => {
+  // Ensure no test run can interfere with the setup of a future test run
   await db.query(`
     DROP SCHEMA public CASCADE;
     CREATE SCHEMA public;
   `);
-  await db.end();
+
+  // Pool instance shared between watch-mode runs, so ending it in teardown interferes with reruns.
+  // In watch mode, you manually interrupt the process anyway
+  // so calling `.end()` only necessary in non-watch test runs where Jest is what exits the process
+  const isWatchMode = watch || watchAll;
+  if (!isWatchMode) {
+    await db.end();
+  }
 };


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because

<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Currently, migrations are only applied to the test DB prior to running Jest. Running Jest once, this is fine - when the process ends, global teardown occurs and resets the DB so nothing persists to potentially mess up a future test run.

But in watch mode, teardown happens between each re-run but migrations aren't reapplied on re-run setup, so the DB is empty. Only truncating all tables would be insufficient teardown. Therefore, migrations should be applied during Jest global setup instead, which'll reapply on each re-run.

## This PR

<!-- A bullet point list of one or more items describing the specific changes. -->
- Moves test migrations to be applied during Jest global setup instead of prior to Jest running
- Prevents DB pool from ending on teardown in watch mode (due to shared instance in the same process)
