### PR TITLE
Replace dotenv with Node built-in

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,4 @@
-require('dotenv').config({ quiet: process.env.NODE_ENV === 'test' });
+process.loadEnvFile();
 
 const config = {
   pointsbot: {

--- a/config.js
+++ b/config.js
@@ -1,4 +1,4 @@
-process.loadEnvFile();
+require('./utils/load-env').load();
 
 const config = {
   pointsbot: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "dbmate": "^2.33.0",
         "discord-api-types": "^0.38.49",
         "discord.js": "^14.26.4",
-        "dotenv": "^17.4.2",
         "glob": "^13.0.6",
         "ioredis": "^5.10.1",
         "pg": "^8.21.0",
@@ -3069,17 +3068,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -10393,11 +10381,6 @@
       "requires": {
         "esutils": "^2.0.2"
       }
-    },
-    "dotenv": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="
     },
     "dunder-proto": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "dbmate": "^2.33.0",
     "discord-api-types": "^0.38.49",
     "discord.js": "^14.26.4",
-    "dotenv": "^17.4.2",
     "glob": "^13.0.6",
     "ioredis": "^5.10.1",
     "pg": "^8.21.0",

--- a/test/global-setup.js
+++ b/test/global-setup.js
@@ -1,4 +1,4 @@
-require('dotenv').config({ quiet: true });
+process.loadEnvFile();
 const MissingEnvVarError = require('../utils/errors/missing-env-var');
 const { execSync } = require('node:child_process');
 

--- a/test/global-setup.js
+++ b/test/global-setup.js
@@ -1,4 +1,4 @@
-process.loadEnvFile();
+require('../utils/load-env').load();
 const MissingEnvVarError = require('../utils/errors/missing-env-var');
 const { execSync } = require('node:child_process');
 

--- a/utils/load-env.js
+++ b/utils/load-env.js
@@ -1,0 +1,12 @@
+exports.load = () => {
+  try {
+    process.loadEnvFile();
+  } catch (error) {
+    // Don't throw if .env doesn't exist
+    // CI test won't have a .env file (sets TEST_DATABASE_URL via config)
+    // and local testing will throw in the mandatory env var key check
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+};


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because

<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Our env needs are simple. Since Node v24.10, `process.loadEnvFile()` is stable and serves our needs just fine, so we can cut down on a dependency.

## This PR

<!-- A bullet point list of one or more items describing the specific changes. -->
- Removes dotenv package
- Uses built-in `process.loadEnvFile()` to load env vars
