### PR TITLE
Replace redundant discord.js REST/api-types imports

### DIFF
--- a/bin/deploy-commands.js
+++ b/bin/deploy-commands.js
@@ -2,8 +2,7 @@
 // This will be automatically run when the bot starts (required in index.js)
 // This script can also be run directly from terminal with: node bin/deploy-commands.js
 
-const { REST } = require('@discordjs/rest');
-const { Routes } = require('discord.js');
+const { REST, Routes } = require('discord.js');
 const { clientId, guildId, token } = require('../config');
 const { registerBotCommand } = require('../events').get('messageCreate');
 const {

--- a/events/message-reaction-add.js
+++ b/events/message-reaction-add.js
@@ -1,5 +1,4 @@
-const { Events } = require('discord.js');
-const { ChannelType } = require('discord-api-types/v10');
+const { ChannelType, Events } = require('discord.js');
 const config = require('../config');
 const BookmarkMessageService = require('../services/bookmark-message.service');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "dbmate": "^2.33.0",
-        "discord-api-types": "^0.38.49",
         "discord.js": "^14.26.4",
         "dotenv": "^17.4.2",
         "glob": "^13.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@discordjs/rest": "^2.6.1",
         "dbmate": "^2.33.0",
         "discord-api-types": "^0.38.49",
         "discord.js": "^14.26.4",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "license": "ISC",
   "dependencies": {
     "dbmate": "^2.33.0",
-    "discord-api-types": "^0.38.49",
     "discord.js": "^14.26.4",
     "dotenv": "^17.4.2",
     "glob": "^13.0.6",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@discordjs/rest": "^2.6.1",
     "dbmate": "^2.33.0",
     "discord-api-types": "^0.38.49",
     "discord.js": "^14.26.4",

--- a/services/bookmark-message.service.js
+++ b/services/bookmark-message.service.js
@@ -1,5 +1,4 @@
-const { EmbedBuilder } = require('discord.js');
-const { RESTJSONErrorCodes } = require('discord-api-types/v10');
+const { EmbedBuilder, RESTJSONErrorCodes } = require('discord.js');
 const config = require('../config');
 
 class BookmarkMessageService {

--- a/services/getting-hired-message.service.js
+++ b/services/getting-hired-message.service.js
@@ -1,4 +1,4 @@
-const { RESTJSONErrorCodes } = require('discord-api-types/v9');
+const { RESTJSONErrorCodes } = require('discord.js');
 const RedisService = require('./redis');
 
 class GettingHiredMessageService {

--- a/services/moderation-message-delete.service.js
+++ b/services/moderation-message-delete.service.js
@@ -1,5 +1,8 @@
-const { RESTJSONErrorCodes } = require('discord-api-types/v10');
-const { EmbedBuilder, MessageFlags } = require('discord.js');
+const {
+  EmbedBuilder,
+  MessageFlags,
+  RESTJSONErrorCodes,
+} = require('discord.js');
 const ThreadCreator = require('../utils/thread-creator');
 const { modmailUserId, channels } = require('../config');
 

--- a/utils/can-open-private-thread.js
+++ b/utils/can-open-private-thread.js
@@ -1,4 +1,4 @@
-const { GuildPremiumTier } = require('discord-api-types/v10');
+const { GuildPremiumTier } = require('discord.js');
 
 function canOpenPrivateThread(tier) {
   return [GuildPremiumTier.Tier2, GuildPremiumTier.Tier3].includes(tier);

--- a/utils/thread-creator.js
+++ b/utils/thread-creator.js
@@ -1,4 +1,4 @@
-const { ChannelType } = require('discord-api-types/v10');
+const { ChannelType } = require('discord.js');
 const canOpenPrivateThread = require('./can-open-private-thread');
 
 const ThreadCreator = () => ({


### PR DESCRIPTION

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because

<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
We have a separate dep listing for `@discordjs/rest` and import `REST` from it in `bin/deploy-commands.js`.
But this constructor is referentially equal to the `REST` constructor exported by `discord.js` itself, i.e. the deep import is redundant.

The same applies for `discord-api-types`. Importing the same enums from `discord.js` gives referentially equal objects.

## This PR

<!-- A bullet point list of one or more items describing the specific changes. -->
- Removes redundant `@discord/rest` and `discord-api-types` dep listings (packages included with `discord.js`)
- Replaces redundant deep import in `bin/deploy-commands.js`
- Imports discord.js enums from `discord.js` package directly