### PR TITLE
Revert "Revert "Chore(deps): Bump undici and discord.js""

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "dbmate": "^2.33.0",
-        "discord.js": "^14.26.4",
+        "discord.js": "^14.27.0",
         "dotenv": "^17.4.2",
         "glob": "^13.0.6",
         "ioredis": "^5.10.1",
@@ -654,34 +654,25 @@
       }
     },
     "node_modules/@discordjs/rest": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.1.tgz",
-      "integrity": "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.3.tgz",
+      "integrity": "sha512-wvOylxNYJkwKjctS/Mn5GP1w9r3/rzyH+ThD1JlAca6zEdlHs8QWBBUQJpU5Q+W6DoIj/Ljh1IPlZs7hTU+UAg==",
       "dependencies": {
         "@discordjs/collection": "^2.1.1",
         "@discordjs/util": "^1.2.0",
         "@sapphire/async-queue": "^1.5.3",
         "@sapphire/snowflake": "^3.5.5",
         "@vladfrangu/async_event_emitter": "^2.4.6",
-        "discord-api-types": "^0.38.40",
+        "discord-api-types": "^0.38.50",
         "magic-bytes.js": "^1.13.0",
         "tslib": "^2.6.3",
-        "undici": "6.24.1"
+        "undici": "^6.27.0"
       },
       "engines": {
         "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/@discordjs/rest/node_modules/@sapphire/snowflake": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
-      "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
-      "engines": {
-        "node": ">=v14.0.0",
-        "npm": ">=7.0.0"
       }
     },
     "node_modules/@discordjs/util": {
@@ -1618,9 +1609,9 @@
       }
     },
     "node_modules/@sapphire/snowflake": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
-      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+      "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -3018,28 +3009,28 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.38.49",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.49.tgz",
-      "integrity": "sha512-XnqcWmnFZFAE8ZM8SHAw9DIV8D3Or00rMQ8iQLotrEA2PmXhl+ykaf6L6q4l474hrSUH1JaYcv+iOMRWp2p6Tg=="
+      "version": "0.38.51",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.51.tgz",
+      "integrity": "sha512-SnaFHd+b8Z3HgjEIoSA1wkstXCt6J0Zrxvny0BJZZz7AhmFSetRY3DMrIdO3LFDMeeTxF7WKornnAGxaws5Adw=="
     },
     "node_modules/discord.js": {
-      "version": "14.26.4",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.26.4.tgz",
-      "integrity": "sha512-4oBp8tc6Kf8IDBwAHhbsMaAqx1b5fob9SNasZT7V6yyyUydoO5i5fGuX7TmvRtR+q/WgKRnRViRoAWnG7fNyvA==",
+      "version": "14.27.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.27.0.tgz",
+      "integrity": "sha512-qHbFlFG2N7y3LjPySYsL6A1+BnX6bkTVgo842EX0CqVPk/KTMwZkojPHEXKsQUpWZNyz5BISNHK1cPpQw0+m4A==",
       "dependencies": {
         "@discordjs/builders": "^1.14.1",
         "@discordjs/collection": "1.5.3",
         "@discordjs/formatters": "^0.6.2",
-        "@discordjs/rest": "^2.6.1",
+        "@discordjs/rest": "^2.6.2",
         "@discordjs/util": "^1.2.0",
         "@discordjs/ws": "^1.2.3",
-        "@sapphire/snowflake": "3.5.3",
-        "discord-api-types": "^0.38.40",
+        "@sapphire/snowflake": "3.5.5",
+        "discord-api-types": "^0.38.49",
         "fast-deep-equal": "3.1.3",
         "lodash.snakecase": "4.1.1",
         "magic-bytes.js": "^1.13.0",
         "tslib": "^2.6.3",
-        "undici": "6.24.1"
+        "undici": "^6.27.0"
       },
       "engines": {
         "node": ">=18"
@@ -7912,9 +7903,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "engines": {
         "node": ">=18.17"
       }
@@ -8701,26 +8692,19 @@
       }
     },
     "@discordjs/rest": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.1.tgz",
-      "integrity": "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.3.tgz",
+      "integrity": "sha512-wvOylxNYJkwKjctS/Mn5GP1w9r3/rzyH+ThD1JlAca6zEdlHs8QWBBUQJpU5Q+W6DoIj/Ljh1IPlZs7hTU+UAg==",
       "requires": {
         "@discordjs/collection": "^2.1.1",
         "@discordjs/util": "^1.2.0",
         "@sapphire/async-queue": "^1.5.3",
         "@sapphire/snowflake": "^3.5.5",
         "@vladfrangu/async_event_emitter": "^2.4.6",
-        "discord-api-types": "^0.38.40",
+        "discord-api-types": "^0.38.50",
         "magic-bytes.js": "^1.13.0",
         "tslib": "^2.6.3",
-        "undici": "6.24.1"
-      },
-      "dependencies": {
-        "@sapphire/snowflake": {
-          "version": "3.5.5",
-          "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
-          "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ=="
-        }
+        "undici": "^6.27.0"
       }
     },
     "@discordjs/util": {
@@ -9406,9 +9390,9 @@
       }
     },
     "@sapphire/snowflake": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
-      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+      "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ=="
     },
     "@sinclair/typebox": {
       "version": "0.34.49",
@@ -10349,28 +10333,28 @@
       "dev": true
     },
     "discord-api-types": {
-      "version": "0.38.49",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.49.tgz",
-      "integrity": "sha512-XnqcWmnFZFAE8ZM8SHAw9DIV8D3Or00rMQ8iQLotrEA2PmXhl+ykaf6L6q4l474hrSUH1JaYcv+iOMRWp2p6Tg=="
+      "version": "0.38.51",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.51.tgz",
+      "integrity": "sha512-SnaFHd+b8Z3HgjEIoSA1wkstXCt6J0Zrxvny0BJZZz7AhmFSetRY3DMrIdO3LFDMeeTxF7WKornnAGxaws5Adw=="
     },
     "discord.js": {
-      "version": "14.26.4",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.26.4.tgz",
-      "integrity": "sha512-4oBp8tc6Kf8IDBwAHhbsMaAqx1b5fob9SNasZT7V6yyyUydoO5i5fGuX7TmvRtR+q/WgKRnRViRoAWnG7fNyvA==",
+      "version": "14.27.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.27.0.tgz",
+      "integrity": "sha512-qHbFlFG2N7y3LjPySYsL6A1+BnX6bkTVgo842EX0CqVPk/KTMwZkojPHEXKsQUpWZNyz5BISNHK1cPpQw0+m4A==",
       "requires": {
         "@discordjs/builders": "^1.14.1",
         "@discordjs/collection": "1.5.3",
         "@discordjs/formatters": "^0.6.2",
-        "@discordjs/rest": "^2.6.1",
+        "@discordjs/rest": "^2.6.2",
         "@discordjs/util": "^1.2.0",
         "@discordjs/ws": "^1.2.3",
-        "@sapphire/snowflake": "3.5.3",
-        "discord-api-types": "^0.38.40",
+        "@sapphire/snowflake": "3.5.5",
+        "discord-api-types": "^0.38.49",
         "fast-deep-equal": "3.1.3",
         "lodash.snakecase": "4.1.1",
         "magic-bytes.js": "^1.13.0",
         "tslib": "^2.6.3",
-        "undici": "6.24.1"
+        "undici": "^6.27.0"
       },
       "dependencies": {
         "@discordjs/collection": {
@@ -13749,9 +13733,9 @@
       "dev": true
     },
     "undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA=="
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA=="
     },
     "unrs-resolver": {
       "version": "1.12.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "ISC",
   "dependencies": {
     "dbmate": "^2.33.0",
-    "discord.js": "^14.26.4",
+    "discord.js": "^14.27.0",
     "dotenv": "^17.4.2",
     "glob": "^13.0.6",
     "ioredis": "^5.10.1",


### PR DESCRIPTION
Reverts TheOdinProject/odin-bot-v2#880

#880 revert was due to #879 failing post-merge CI (https://github.com/TheOdinProject/odin-bot-v2/actions/runs/30176096927), despite passing PR CI.

Not sure why CI passed again after revert, testing if coincidence because the failure reason shouldn't have had anything to do with updating discord.js or Undici (failure occurred on `docker pull postgres` before any Node/npm stuff involved).

