### PR TITLE
Allow unrs-resolver@1.12.2 install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
       "prettier --check",
       "eslint"
     ]
+  },
+  "allowScripts": {
+    "unrs-resolver@1.12.2": true
   }
 }


### PR DESCRIPTION

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because

<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
npm v11.19+ now warns about unhandled pre-post/install scripts and npm v12 will block them if unhandled.

This is the only such script we have and it's used by Jest.
Verified and pinned to version - see see unrs/unrs-resolver#213 (comment)


## This PR

<!-- A bullet point list of one or more items describing the specific changes. -->
- Allows install script for urns-resolver@1.12.2 to run
