### PR TITLE
/points user: Add username display in embed title

### DIFF
--- a/services/points/points.service.js
+++ b/services/points/points.service.js
@@ -109,10 +109,11 @@ Our goal is to maintain a positive and supportive community, where help and cont
     // rank is 1-indexed
     const rank = allUsers.findIndex((user) => user === userInDatabase) + 1;
     const displayName = escapeMarkdown(guildMember.displayName);
+    const username = escapeMarkdown(guildMember.user.username);
 
     const userPointsEmbed = new EmbedBuilder()
       .setColor('#cc9543')
-      .setTitle(`TOP Discord points for ${displayName}`)
+      .setTitle(`TOP Discord points for ${displayName} *(${username})*`)
       .addFields([
         {
           name: 'Points',

--- a/services/points/points.service.test.js
+++ b/services/points/points.service.test.js
@@ -22,7 +22,7 @@ afterAll(async () => {
 
 const guild = new Guild({
   members: mockUsers.inGuild.map(
-    ({ id, username }) => new GuildMember({ id, username }),
+    ({ id, username, nickname }) => new GuildMember({ id, username, nickname }),
   ),
 });
 
@@ -42,7 +42,7 @@ describe('user', () => {
 
     const botReply = await interaction.reply.mock.results[0]?.value;
     expect(botReply.embeds[0].data).toMatchObject({
-      title: 'TOP Discord points for User 0',
+      title: 'TOP Discord points for User 0 *(User 0)*',
       fields: [
         { name: 'Points', value: 'User 0 has 0 points.' },
         { name: 'Rank', value: 'User 0 is not on the leaderboard.' },
@@ -66,7 +66,7 @@ describe('user', () => {
 
     const botReply = await interaction.reply.mock.results[0]?.value;
     expect(botReply.embeds[0].data).toMatchObject({
-      title: 'TOP Discord points for User 5',
+      title: 'TOP Discord points for User 5 *(User 5)*',
       fields: [
         { name: 'Points', value: 'User 5 has 5 points.' },
         { name: 'Rank', value: 'User 5 is ranked number 26.' },
@@ -80,7 +80,7 @@ describe('user', () => {
 
     const botReply = await interaction.reply.mock.results[0]?.value;
     expect(botReply.embeds[0].data).toMatchObject({
-      title: 'TOP Discord points for User 1',
+      title: 'TOP Discord points for User 1 *(User 1)*',
       fields: [
         { name: 'Points', value: 'User 1 has 1 point.' },
         { name: 'Rank', value: 'User 1 is ranked number 30.' },
@@ -94,7 +94,7 @@ describe('user', () => {
 
     const botReply = await interaction.reply.mock.results[0]?.value;
     expect(botReply.embeds[0].data).toMatchObject({
-      title: 'TOP Discord points for User 30',
+      title: 'TOP Discord points for User 30 *(User 30)*',
       fields: [
         { name: 'Points', value: 'User 30 has 30 points.' },
         { name: 'Rank', value: 'User 30 is ranked number 1 :tada:' },
@@ -108,13 +108,27 @@ describe('user', () => {
 
     const botReply = await interaction.reply.mock.results[0]?.value;
     expect(botReply.embeds[0].data).toMatchObject({
-      title: 'TOP Discord points for User \\*\\*4\\*\\*',
+      title: 'TOP Discord points for User \\*\\*4\\*\\* *(User \\*\\*4\\*\\*)*',
       fields: [
         { name: 'Points', value: 'User \\*\\*4\\*\\* has 4 points.' },
         {
           name: 'Rank',
           value: 'User \\*\\*4\\*\\* is ranked number 27.',
         },
+      ],
+    });
+  });
+
+  it("Displays both user's username and nickname", async () => {
+    const interaction = createInteraction(new User(mockUsers.all[32]));
+    await PointsService.handleInteraction(interaction);
+
+    const botReply = await interaction.reply.mock.results[0]?.value;
+    expect(botReply.embeds[0].data).toMatchObject({
+      title: 'TOP Discord points for notuser32 *(User 32)*',
+      fields: [
+        { name: 'Points', value: 'notuser32 has 0 points.' },
+        { name: 'Rank', value: 'notuser32 is not on the leaderboard.' },
       ],
     });
   });

--- a/test/mocks/database-users/slash-commands.js
+++ b/test/mocks/database-users/slash-commands.js
@@ -31,6 +31,7 @@ const mockUsers = [
   { id: '29', username: 'User 29', points: 29 },
   { id: '30', username: 'User 30', points: 30 },
   { id: 'NotInGuild', username: 'User NotInGuild', points: 1000 },
+  { id: '32', username: 'User 32', points: 0, nickname: 'notuser32' },
 ];
 
 module.exports = {


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because

<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->

`/points user` command currently only display a user's display name in a server and not their actual username. This PR aims to add username in the embed title when running `/points user` to create distinction between users. 

## This PR

<!-- A bullet point list of one or more items describing the specific changes. -->
- Add username display wrapped in italicized parentheses (example: _(vietanhhoang2507)_) 
- Amend test cases to account for also displaying username. If a user's server display name is not found, it displays a user's username twice.
- Add a test case for displaying both names. If there is a server display name, display the user's display name first then username in the format described above

## Issue

<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->

Closes #906 

## Additional Information

<!-- Any other information about this PR, such as a link to a Discord discussion. -->

Screenshot example attached below

<img width="451" height="204" alt="image" src="https://github.com/user-attachments/assets/ffa1aff4-ef69-4db3-98c5-74ed9629bf6b" />

Also, when running `npm run migrate`, my `schema.sql` file makes some changes automatically that does not matches with upstream's `schema.sql`. I do not know why these changes are made nor how this would affect upstream so if these unintended changes do affect odin-bot, let me know and I'll remove the schema changes.

## Pull Request Requirements

<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->

- [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Callbacks command: Update verbiage`
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [x] If this PR addresses an open issue, it is linked in the `Issue` section
- [x] If this PR adds new features or functionality, I have added new tests
- [x] If applicable, I have ensured all tests related to any command files included in this PR pass, and/or all snapshots are up to date
