### PR TITLE
Use `migrate:only` script for migrations in setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Leaving the other items as they are with their `''` will not cause issues for no
    DATABASE_URL=postgresql://username:password@localhost:5432/odinbot_development?sslmode=disable
    ```
 
-1. Run `npm run migrate` to apply all the migrations and ensure your development database follows the most up-to-date schema. The bot will not start if there are pending migrations.
+1. Run `npm run migrate:only` to apply all the migrations and ensure your development database follows the most up-to-date schema. The bot will not start if there are pending migrations.
 
 ### Install Redis
 


### PR DESCRIPTION

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because

<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Schema dump only needed when running new/rolling back migrations (as those would change the schema). Applying migrations when setting up the bot does not need to dump the schema. Avoids unwanted diff noise

## This PR

<!-- A bullet point list of one or more items describing the specific changes. -->
- Amends setup instructions to use `migrate:only` instead of `migrate` script.

